### PR TITLE
Timer registry support

### DIFF
--- a/src/OrleansTestKit/TestGrainRuntime.cs
+++ b/src/OrleansTestKit/TestGrainRuntime.cs
@@ -24,10 +24,10 @@ namespace Orleans.TestKit
 
         public IServiceProvider ServiceProvider { get; }
 
-        public TestGrainRuntime(IGrainFactory grainFactory,
-            IStreamProviderManager streamProviderManager)
+        public TestGrainRuntime(IGrainFactory grainFactory, ITimerRegistry timerRegistry, IStreamProviderManager streamProviderManager)
         {
             GrainFactory = grainFactory;
+            TimerRegistry = timerRegistry;
             StreamProviderManager = streamProviderManager;
         }
 

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -5,6 +5,7 @@ using Orleans.Core;
 using Orleans.Runtime;
 using Orleans.TestKit.Storage;
 using Orleans.TestKit.Streams;
+using Orleans.TestKit.Timers;
 
 namespace Orleans.TestKit
 {
@@ -23,6 +24,8 @@ namespace Orleans.TestKit
 
         private readonly TestGrainFactory _grainFactory;
 
+        private readonly TestTimerRegistry _timerRegistry;
+
         private readonly TestStreamProviderManager _streamProviderManager;
 
         private readonly GrainStateManager _grainStateManager = new GrainStateManager();
@@ -37,9 +40,11 @@ namespace Orleans.TestKit
 
             _serviceProvider = new TestServiceProvider(Options);
 
+            _timerRegistry = new TestTimerRegistry();
+
             _streamProviderManager = new TestStreamProviderManager(Options);
 
-            var grainRuntime = new TestGrainRuntime(_grainFactory, _streamProviderManager);
+            var grainRuntime = new TestGrainRuntime(_grainFactory, _timerRegistry, _streamProviderManager);
 
             _grainCreator = new GrainCreator(_serviceProvider, () => grainRuntime);
         }
@@ -119,11 +124,15 @@ namespace Orleans.TestKit
 
         #region Timers
 
-        //        protected void FireAllTimers()
-        //        {
-        //           _grainRuntime.FireAllTimers();
-        //        }
+        public void FireTimer(int index)
+        {
+            _timerRegistry.Fire(index);
+        }
 
+        public void FireAllTimers()
+        {
+            _timerRegistry.FireAll();
+        }
 
         #endregion
 

--- a/src/OrleansTestKit/Timers/TestTimer.cs
+++ b/src/OrleansTestKit/Timers/TestTimer.cs
@@ -1,25 +1,28 @@
-//namespace OrleansNonSiloTesting
-//{
-//    public class TestTimer : IDisposable
-//    {
-//        private Func<object, Task> _asyncCallback;
-//        private object _state;
-//
-//        public TestTimer(Func<object, Task> asyncCallback, object state)
-//        {
-//            _asyncCallback = asyncCallback;
-//            _state = state;
-//        }
-//
-//        public void Fire()
-//        {
-//            _asyncCallback?.Invoke(_state);
-//        }
-//
-//        public void Dispose()
-//        {
-//            _asyncCallback = null;
-//            _state = null;
-//        }
-//    }
-//}
+using System;
+using System.Threading.Tasks;
+
+namespace Orleans.TestKit.Timers
+{
+    public class TestTimer : IDisposable
+    {
+        private Func<object, Task> _asyncCallback;
+        private object _state;
+
+        public TestTimer(Func<object, Task> asyncCallback, object state)
+        {
+            _asyncCallback = asyncCallback;
+            _state = state;
+        }
+
+        public void Fire()
+        {
+            _asyncCallback?.Invoke(_state);
+        }
+
+        public void Dispose()
+        {
+            _asyncCallback = null;
+            _state = null;
+        }
+    }
+}

--- a/src/OrleansTestKit/Timers/TestTimerRegistry.cs
+++ b/src/OrleansTestKit/Timers/TestTimerRegistry.cs
@@ -1,29 +1,37 @@
-//namespace OrleansNonSiloTesting
-//{
-//    public class TestTimerRegistry : ITimerRegistry
-//    {
-//        private readonly List<TestTimer> _timers = new List<TestTimer>();
-//
-//        public readonly Mock<ITimerRegistry> Mock = new Mock<ITimerRegistry>();
-//
-//        public IDisposable RegisterTimer(Grain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime,
-//            TimeSpan period)
-//        {
-//            //Trigger the internal mock so it can be verified
-//            Mock.Object.RegisterTimer(grain, asyncCallback, state, dueTime, period);
-//
-//            var timer = new TestTimer(asyncCallback, state);
-//            _timers.Add(timer);
-//
-//            return timer;
-//        }
-//
-//        public void FireAll()
-//        {
-//            foreach (var testTimer in _timers)
-//            {
-//                testTimer.Fire();
-//            }
-//        }
-//    }
-//}
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using Orleans.Timers;
+
+namespace Orleans.TestKit.Timers
+{
+    public class TestTimerRegistry : ITimerRegistry
+    {
+        private readonly List<TestTimer> _timers = new List<TestTimer>();
+
+        public readonly Mock<ITimerRegistry> Mock = new Mock<ITimerRegistry>();
+
+        public IDisposable RegisterTimer(Grain grain, Func<object, Task> asyncCallback, object state, TimeSpan dueTime, TimeSpan period)
+        {
+            // Trigger the internal mock so it can be verified
+            Mock.Object.RegisterTimer(grain, asyncCallback, state, dueTime, period);
+
+            var timer = new TestTimer(asyncCallback, state);
+            _timers.Add(timer);
+
+            return timer;
+        }
+
+        public void Fire(int index)
+        {
+            _timers[index].Fire();
+        }
+
+        public void FireAll()
+        {
+            foreach (var testTimer in _timers)
+                testTimer.Fire();
+        }
+    }
+}

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="GrainProbeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StreamTests.cs" />
+    <Compile Include="TimerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/test/OrleansTestKit.Tests/TimerTests.cs
+++ b/test/OrleansTestKit.Tests/TimerTests.cs
@@ -1,0 +1,54 @@
+﻿using FluentAssertions;
+using TestGrains;
+using Xunit;
+
+namespace Orleans.TestKit.Tests
+{
+    public class TimerTests : TestKitBase
+    {
+        [Fact]
+        public void ShouldFireAllTimers()
+        {
+            // Arrange
+            var grain = Silo.CreateGrain<HelloTimers>(0);
+
+            // Act
+            Silo.FireAllTimers();
+
+            // Assert
+            var state = Silo.State<HelloTimersState>(grain);
+            state.Timer0Fired.Should().BeTrue();
+            state.Timer1Fired.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ShouldFireFirstTimer()
+        {
+            // Arrange
+            var grain = Silo.CreateGrain<HelloTimers>(0);
+
+            // Act
+            Silo.FireTimer(0);
+
+            // Assert
+            var state = Silo.State<HelloTimersState>(grain);
+            state.Timer0Fired.Should().BeTrue();
+            state.Timer1Fired.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ShouldFireSecondTimer()
+        {
+            // Arrange
+            var grain = Silo.CreateGrain<HelloTimers>(0);
+
+            // Act
+            Silo.FireTimer(1);
+
+            // Assert
+            var state = Silo.State<HelloTimersState>(grain);
+            state.Timer0Fired.Should().BeFalse();
+            state.Timer1Fired.Should().BeTrue();
+        }
+    }
+}

--- a/test/TestGrains/HelloTimers.cs
+++ b/test/TestGrains/HelloTimers.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace TestGrains
+{
+    public class HelloTimers : Grain<HelloTimersState>, IGrainWithIntegerKey
+    {
+        private IDisposable _timer0;
+        private IDisposable _timer1;
+
+        public override Task OnActivateAsync()
+        {
+            _timer0 = RegisterTimer(_ => OnTimer0(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            _timer1 = RegisterTimer(_ => OnTimer1(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+
+            return base.OnActivateAsync();
+        }
+
+        public override Task OnDeactivateAsync()
+        {
+            _timer0.Dispose();
+            _timer1.Dispose();
+
+            return base.OnDeactivateAsync();
+        }
+
+        private Task OnTimer0()
+        {
+            State.Timer0Fired = true;
+            return TaskDone.Done;
+        }
+
+        private Task OnTimer1()
+        {
+            State.Timer1Fired = true;
+            return TaskDone.Done;
+        }
+    }
+
+    public class HelloTimersState
+    {
+        public HelloTimersState()
+        {
+            Timer0Fired = false;
+            Timer1Fired = false;
+        }
+
+        public bool Timer0Fired { get; set; }
+
+        public bool Timer1Fired { get; set; }
+    }
+}

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -63,6 +63,7 @@
     <Compile Include="HelloArchiveGrain.cs" />
     <Compile Include="HelloGrain.cs" />
     <Compile Include="HelloGrainWithServiceDependency.cs" />
+    <Compile Include="HelloTimers.cs" />
     <Compile Include="LifecycleGrain.cs" />
     <Compile Include="Listener.cs" />
     <Compile Include="PingGrain.cs" />


### PR DESCRIPTION
* uncomment test timer registry.
* add support for firing timer by index, in order of registration.

TimerTests.cs contains example of usage.
