### PR TITLE
Probe factories for non-strict probe grains

### DIFF
--- a/src/OrleansTestKit/Storage/TestStorage.cs
+++ b/src/OrleansTestKit/Storage/TestStorage.cs
@@ -16,21 +16,21 @@ namespace Orleans.TestKit.Storage
         {
             Stats.Clears++;
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task WriteStateAsync()
         {
             Stats.Writes++;
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public Task ReadStateAsync()
         {
             Stats.Reads++;
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrleansTestKit/Streams/TestStreamProvider.cs
+++ b/src/OrleansTestKit/Streams/TestStreamProvider.cs
@@ -43,12 +43,12 @@ namespace Orleans.TestKit.Streams
         {
             Name = name;
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
-        public Task Close() => TaskDone.Done;
+        public Task Close() => Task.CompletedTask;
 
-        public Task Start() => TaskDone.Done;
+        public Task Start() => Task.CompletedTask;
 
         public TestStream<T> AddStreamProbe<T>(Guid streamId, string streamNamespace)
         {

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -185,6 +185,9 @@ namespace Orleans.TestKit
         public Mock<T> AddProbe<T>(string id) where T : class, IGrain
             => _grainFactory.AddProbe<T>(new TestGrainIdentity(id));
 
+        public void AddProbeFactory<T>(Func<IGrainIdentity, IMock<T>> factory) where T : class, IGrain
+            => _grainFactory.AddProbeFactory<T>(factory);
+
         #endregion
 
         #region Storage & State

--- a/test/OrleansTestKit.Tests/GrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/GrainProbeTests.cs
@@ -90,5 +90,20 @@ namespace Orleans.TestKit.Tests
             probe.Should().NotBeNull();
             key.Should().BeNull();
         }
+
+        [Fact]
+        public async Task FactoryProbe() 
+        {
+
+            var pong = new Mock<IPong>();
+
+            this.Silo.AddProbeFactory<IPong>(identity => pong);
+
+            var grain = this.Silo.CreateGrain<PingGrain>(1);
+
+            await grain.Ping();
+
+            pong.Verify(p => p.Pong(), Times.Once);
+        }
     }
 }

--- a/test/OrleansTestKit.Tests/StrictGrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/StrictGrainProbeTests.cs
@@ -30,7 +30,7 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public async Task MissingProbe()
+        public void MissingProbe()
         {
             IPing grain = Silo.CreateGrain<PingGrain>(1);
 
@@ -38,7 +38,7 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public async Task InvalidProbe()
+        public void InvalidProbe()
         {
             IPing grain = Silo.CreateGrain<PingGrain>(1);
 
@@ -51,7 +51,7 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public async Task InvalidProbeType()
+        public void InvalidProbeType()
         {
             IPing grain = Silo.CreateGrain<PingGrain>(1);
 

--- a/test/TestGrains/HelloReminders.cs
+++ b/test/TestGrains/HelloReminders.cs
@@ -13,9 +13,10 @@ namespace TestGrains
         public Task RegisterReminder(string reminderName,TimeSpan dueTime, TimeSpan period) =>
             this.RegisterOrUpdateReminder(reminderName, dueTime, period);
 
-        async Task IRemindable.ReceiveReminder(string reminderName, TickStatus status)
+        Task IRemindable.ReceiveReminder(string reminderName, TickStatus status)
         {
             FiredReminders.Add(reminderName);
+            return Task.CompletedTask;
         }
 
         public async Task UnregisterReminder(string reminderName)

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -41,7 +41,7 @@
       <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Orleans, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -87,7 +87,7 @@
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">


### PR DESCRIPTION
This PR adds the ability to specify a factory function to be used when creating grain probes in non-strict mode.

```csharp
this.Silo.AddProbeFactory<IPong>(identity => new Mock<IPong>());
```

A factory is only used when creating a grain if no specific grain already exists and the mode is non-strict.