### PR TITLE
Allow stream probes to be created for providers other than 'Default'

### DIFF
--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -143,11 +143,16 @@ namespace Orleans.TestKit
 
         public TestStream<T> AddStreamProbe<T>() where T : class => AddStreamProbe<T>(Guid.Empty);
 
-        public TestStream<T> AddStreamProbe<T>(Guid id, string streamNamespace) where T : class
-            => _streamProviderManager.AddStreamProbe<T>(id, streamNamespace, "Default");
-
         public TestStream<T> AddStreamProbe<T>(Guid id) where T : class
             => AddStreamProbe<T>(id, typeof(T).Name);
+
+        public TestStream<T> AddStreamProbe<T>(Guid id, string streamNamespace) where T : class
+            => AddStreamProbe<T>(id, streamNamespace, "Default");
+
+        public TestStream<T> AddStreamProbe<T>(Guid id, string streamNamespace, string providerName) where T : class
+            => _streamProviderManager.AddStreamProbe<T>(id, streamNamespace, providerName);
+
+        
 
         #endregion
 


### PR DESCRIPTION
This PR allows stream probes to be created for providers other than `Default`:

```csharp
this.Silo.AddStreamProbe<Message>(Guid.Empty, null, "Messages");
```