### PR TITLE
Update to Orleans v1.5

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+root = true
+
+[*]
+indent_style = space
+
+[*.cs]
+indent_size = 4
+insert_final_newline = true
+
+[*.{csproj,json}]
+indent_size = 2
+
+[*.cs]
+dotnet_sort_system_directives_first = true
+
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
+
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -51,12 +51,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+    <Reference Include="Orleans, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.2\lib\net451\Orleans.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OrleansRuntime, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.OrleansRuntime.1.4.0\lib\net451\OrleansRuntime.dll</HintPath>
+    <Reference Include="OrleansRuntime, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.OrleansRuntime.1.4.2\lib\net451\OrleansRuntime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -80,6 +80,7 @@
     <Compile Include="Streams\TestStream.cs" />
     <Compile Include="Streams\TestStreamId.cs" />
     <Compile Include="Streams\TestStreamSubscriptionHandle.cs" />
+    <Compile Include="TestGrainActivationContext.cs" />
     <Compile Include="TestKitOptions.cs" />
     <Compile Include="TestKitSilo.cs" />
     <Compile Include="TestGrainFactory.cs" />

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.TestKit</RootNamespace>
     <AssemblyName>OrleansTestKit</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -35,13 +35,14 @@
       <HintPath>..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.1.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.7.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.7.0\lib\net45\Moq.dll</HintPath>
@@ -51,24 +52,75 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.2\lib\net451\Orleans.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Orleans, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.5.0\lib\net461\Orleans.dll</HintPath>
     </Reference>
-    <Reference Include="OrleansRuntime, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.OrleansRuntime.1.4.2\lib\net451\OrleansRuntime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="OrleansRuntime, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.OrleansRuntime.1.5.0\lib\net461\OrleansRuntime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -81,6 +133,7 @@
     <Compile Include="Streams\TestStreamId.cs" />
     <Compile Include="Streams\TestStreamSubscriptionHandle.cs" />
     <Compile Include="TestGrainActivationContext.cs" />
+    <Compile Include="TestGrainCreator.cs" />
     <Compile Include="TestKitOptions.cs" />
     <Compile Include="TestKitSilo.cs" />
     <Compile Include="TestGrainFactory.cs" />

--- a/src/OrleansTestKit/Properties/AssemblyInfo.cs
+++ b/src/OrleansTestKit/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.1.0")]
-[assembly: AssemblyFileVersion("0.1.1.0")]
-[assembly: AssemblyInformationalVersion("0.1.1")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyInformationalVersion("0.2.0")]

--- a/src/OrleansTestKit/Streams/TestStreamSubscriptionHandle.cs
+++ b/src/OrleansTestKit/Streams/TestStreamSubscriptionHandle.cs
@@ -12,6 +12,8 @@ namespace Orleans.TestKit.Streams
 
         public override Guid HandleId { get {throw new NotImplementedException();} }
 
+        public override string ProviderName { get { throw new NotImplementedException(); } }
+
         public TestStreamSubscriptionHandle(Action unsubscribe)
         {
             _unsubscribe = unsubscribe;
@@ -20,7 +22,7 @@ namespace Orleans.TestKit.Streams
         public override Task UnsubscribeAsync()
         {
             _unsubscribe();
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public override Task<StreamSubscriptionHandle<T>> ResumeAsync(IAsyncObserver<T> observer,

--- a/src/OrleansTestKit/TestGrainActivationContext.cs
+++ b/src/OrleansTestKit/TestGrainActivationContext.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Orleans.Core;
+using Orleans.Runtime;
+
+namespace Orleans.TestKit {
+    public class TestGrainActivationContext : IGrainActivationContext 
+    {
+        public IServiceProvider ActivationServices 
+        {
+            get;
+            set;
+        }
+
+        public IGrainIdentity GrainIdentity 
+        {
+            get;
+            set;
+        }
+
+        public Type GrainType 
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/OrleansTestKit/TestGrainCreator.cs
+++ b/src/OrleansTestKit/TestGrainCreator.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Core;
+using Orleans.Runtime;
+
+namespace Orleans.TestKit
+{
+    public class TestGrainCreator
+    {
+        private readonly IGrainActivator _activator;
+        private readonly IGrainRuntime _runtime;
+        private readonly PropertyInfo _runtimeProperty;
+        private readonly FieldInfo _identityField;
+        private readonly MethodInfo _setStorageMethod;
+
+        public TestGrainCreator(IGrainRuntime runtime)
+        {
+            _runtime = runtime;
+            _activator = new DefaultGrainActivator();
+            _runtimeProperty = typeof(Grain).GetProperty("Runtime", BindingFlags.Instance | BindingFlags.NonPublic);
+            _identityField = typeof(Grain).GetField("Identity", BindingFlags.Instance | BindingFlags.NonPublic);
+            _setStorageMethod = typeof(Grain<>).GetInterfaces().First(i => i.Name == "IStatefulGrain").GetMethod("SetStorage");
+        }
+
+        public Grain CreateGrainInstance(IGrainActivationContext context)
+        {
+            var grain = (Grain)_activator.Create(context);
+
+            //Set the runtime and identity. This is equivalent to what Orleans' GrainCreator does
+            //when creating new grains. It is messier but easier than trying to wrangle the values
+            //in via a constructor which may or may exist on types inheriting from Grain.
+
+            _runtimeProperty.SetValue(grain, _runtime);
+            _identityField.SetValue(grain, context.GrainIdentity);
+
+            return grain;
+        }
+
+        public Grain CreateGrainInstance(IGrainActivationContext context, Type stateType, IStorage storage)
+        {
+            var grain = CreateGrainInstance(context);
+            var baseType = context.GrainType.BaseType;
+
+            if(baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(Grain<>))
+            {
+                //Set the state value
+                var stateProperty = baseType.GetProperty("State", BindingFlags.Instance | BindingFlags.NonPublic);
+                var stateValue = Activator.CreateInstance(stateType);
+
+                stateProperty.SetValue(grain, stateValue);
+
+                //Set the storage provider
+                _setStorageMethod.Invoke(grain, new object[] { storage });
+            }
+
+            return grain;
+        }
+    }
+}

--- a/src/OrleansTestKit/TestGrainCreator.cs
+++ b/src/OrleansTestKit/TestGrainCreator.cs
@@ -42,13 +42,12 @@ namespace Orleans.TestKit
 
         public Grain CreateGrainInstance(IGrainActivationContext context, Type stateType, IStorage storage)
         {
-            var grain = CreateGrainInstance(context);
-            var baseType = context.GrainType.BaseType;
+            var grain = CreateGrainInstance(context);            
 
-            if(baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(Grain<>))
+            if(TypeHelper.IsSubclassOfRawGeneric(context.GrainType, typeof(Grain<>)))
             {
                 //Set the state value
-                var stateProperty = baseType.GetProperty("State", BindingFlags.Instance | BindingFlags.NonPublic);
+                var stateProperty = TypeHelper.GetProperty(context.GrainType, "State");
                 var stateValue = Activator.CreateInstance(stateType);
 
                 stateProperty.SetValue(grain, stateValue);

--- a/src/OrleansTestKit/TestGrainFactory.cs
+++ b/src/OrleansTestKit/TestGrainFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Moq;
 using Orleans.Core;
+using Orleans.Runtime;
 
 namespace Orleans.TestKit
 {
@@ -103,6 +104,10 @@ namespace Orleans.TestKit
             _probes.Add(key, mock.Object);
 
             return mock;
+        }
+
+        public void BindGrainReference(IAddressable grain) {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/OrleansTestKit/TestGrainIdentity.cs
+++ b/src/OrleansTestKit/TestGrainIdentity.cs
@@ -40,9 +40,9 @@ namespace Orleans.TestKit
             }
         }
 
-        public bool IsClient => throw new NotImplementedException();
+        public bool IsClient { get { throw new NotImplementedException(); } }
 
-        public int TypeCode => throw new NotImplementedException();
+        public int TypeCode { get { throw new NotImplementedException(); } }
 
         public TestGrainIdentity(Guid id)
         {

--- a/src/OrleansTestKit/TestGrainIdentity.cs
+++ b/src/OrleansTestKit/TestGrainIdentity.cs
@@ -40,6 +40,10 @@ namespace Orleans.TestKit
             }
         }
 
+        public bool IsClient => throw new NotImplementedException();
+
+        public int TypeCode => throw new NotImplementedException();
+
         public TestGrainIdentity(Guid id)
         {
             PrimaryKey = id;
@@ -64,6 +68,11 @@ namespace Orleans.TestKit
         }
 
         public Guid GetPrimaryKey(out string keyExt)
+        {
+            throw new NotImplementedException();
+        }
+
+        public uint GetUniformHashCode() 
         {
             throw new NotImplementedException();
         }

--- a/src/OrleansTestKit/TestGrainRuntime.cs
+++ b/src/OrleansTestKit/TestGrainRuntime.cs
@@ -27,6 +27,8 @@ namespace Orleans.TestKit
 
         public IServiceProvider ServiceProvider { get; }
 
+        public SiloAddress SiloAddress { get { return SiloAddress.Zero; } }
+
         public TestGrainRuntime(IGrainFactory grainFactory, ITimerRegistry timerRegistry, IStreamProviderManager streamProviderManager)
         {
             GrainFactory = grainFactory;

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -19,7 +19,7 @@ namespace Orleans.TestKit
         /// </summary>
         private bool _isGrainCreated;
 
-        private readonly GrainCreator _grainCreator;
+        private readonly TestGrainCreator _grainCreator;
 
         private readonly TestGrainRuntime _grainRuntime;
 
@@ -49,7 +49,7 @@ namespace Orleans.TestKit
 
             _grainRuntime = new TestGrainRuntime(_grainFactory, _timerRegistry, _streamProviderManager);
 
-            _grainCreator = new GrainCreator(new DefaultGrainActivator(), () => _grainRuntime);
+            _grainCreator = new TestGrainCreator(_grainRuntime);
         }
 
         #region CreateGrains

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -99,7 +99,7 @@ namespace Orleans.TestKit
                 if (grain == null)
                     throw new Exception($"Unable to instantiate stateful grain {typeof(T)} properly");
 
-                var stateProperty = GetProperty(typeof(T), "State");
+                var stateProperty = TypeHelper.GetProperty(typeof(T), "State");
 
                 var state = stateProperty?.GetValue(grain);
 
@@ -118,17 +118,7 @@ namespace Orleans.TestKit
             grain.OnActivateAsync().Wait(1000);
 
             return grain as T;
-        }
-
-        private static PropertyInfo GetProperty(Type t, string name)
-        {
-            var info = t.GetProperty(name, BindingFlags.NonPublic | BindingFlags.Instance);
-
-            if (info == null && t.BaseType != null)
-                return GetProperty(t.BaseType, name);
-
-            return info;
-        }
+        }        
 
         #endregion
 

--- a/src/OrleansTestKit/TypeHelper.cs
+++ b/src/OrleansTestKit/TypeHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace Orleans.TestKit
 {
@@ -24,6 +25,16 @@ namespace Orleans.TestKit
             }
 
             return false;
+        }
+
+        public static PropertyInfo GetProperty(Type t, string name)
+        {
+            var info = t.GetProperty(name, BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (info == null && t.BaseType != null)
+                return GetProperty(t.BaseType, name);
+
+            return info;
         }
     }
 }

--- a/src/OrleansTestKit/app.config
+++ b/src/OrleansTestKit/app.config
@@ -1,55 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.1.0" newVersion="1.0.1.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.1.0" newVersion="1.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/src/OrleansTestKit/app.config
+++ b/src/OrleansTestKit/app.config
@@ -1,55 +1,55 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.1.0" newVersion="1.0.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.0.1.0" newVersion="1.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/src/OrleansTestKit/packages.config
+++ b/src/OrleansTestKit/packages.config
@@ -3,10 +3,22 @@
   <package id="Castle.Core" version="4.0.0" targetFramework="net451" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net451" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.Core" version="1.4.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.OrleansRuntime" version="1.4.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.Core" version="1.4.2" targetFramework="net451" />
+  <package id="Microsoft.Orleans.OrleansRuntime" version="1.4.2" targetFramework="net451" />
   <package id="Moq" version="4.7.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net451" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net451" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net451" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net451" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net451" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net451" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net451" />
 </packages>

--- a/src/OrleansTestKit/packages.config
+++ b/src/OrleansTestKit/packages.config
@@ -1,24 +1,59 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net451" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.Core" version="1.4.2" targetFramework="net451" />
-  <package id="Microsoft.Orleans.OrleansRuntime" version="1.4.2" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.OrleansRuntime" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="Moq" version="4.7.0" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
-  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net451" />
-  <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net451" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net451" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Console" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net451" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net451" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
-  <package id="System.Threading" version="4.0.11" targetFramework="net451" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Orleans.TestKit.Tests</RootNamespace>
     <AssemblyName>OrleansTestKit.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -45,9 +45,14 @@
       <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.1.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.7.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.7.0\lib\net45\Moq.dll</HintPath>
@@ -57,23 +62,73 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.2\lib\net451\Orleans.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Orleans, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.5.0\lib\net461\Orleans.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -55,8 +57,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+    <Reference Include="Orleans, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.2\lib\net451\Orleans.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -104,7 +106,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrleansTestKit\OrleansTestKit.csproj">

--- a/test/OrleansTestKit.Tests/app.config
+++ b/test/OrleansTestKit.Tests/app.config
@@ -1,55 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.1.0" newVersion="1.0.1.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/test/OrleansTestKit.Tests/app.config
+++ b/test/OrleansTestKit.Tests/app.config
@@ -1,55 +1,55 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.1.0" newVersion="1.0.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.0.1.0" newVersion="1.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/test/OrleansTestKit.Tests/packages.config
+++ b/test/OrleansTestKit.Tests/packages.config
@@ -2,12 +2,60 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net451" />
   <package id="FluentAssertions" version="4.19.0" targetFramework="net451" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.Core" version="1.4.2" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="Moq" version="4.7.0" targetFramework="net451" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Console" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
   <package id="xunit" version="2.2.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net451" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net451" />

--- a/test/OrleansTestKit.Tests/packages.config
+++ b/test/OrleansTestKit.Tests/packages.config
@@ -13,5 +13,5 @@
   <package id="xunit.assert" version="2.2.0" targetFramework="net451" />
   <package id="xunit.core" version="2.2.0" targetFramework="net451" />
   <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net451" />
-  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net451" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net451" requireReinstallation="true" />
 </packages>

--- a/test/OrleansTestKit.Tests/packages.config
+++ b/test/OrleansTestKit.Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.0.0" targetFramework="net451" />
   <package id="FluentAssertions" version="4.19.0" targetFramework="net451" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.Core" version="1.4.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.Core" version="1.4.2" targetFramework="net451" />
   <package id="Moq" version="4.7.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net451" />

--- a/test/TestGrains/DeactivationGrain.cs
+++ b/test/TestGrains/DeactivationGrain.cs
@@ -11,14 +11,14 @@ namespace TestGrains
         {
             base.DeactivateOnIdle();
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         public new Task DelayDeactivation(TimeSpan timeSpan)
         {
             base.DelayDeactivation(timeSpan);
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/HelloGrain.cs
+++ b/test/TestGrains/HelloGrain.cs
@@ -17,7 +17,7 @@ namespace TestGrains
         {
             Deactivated = true;
 
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/TestGrains/HelloTimers.cs
+++ b/test/TestGrains/HelloTimers.cs
@@ -28,13 +28,13 @@ namespace TestGrains
         private Task OnTimer0()
         {
             State.Timer0Fired = true;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
 
         private Task OnTimer1()
         {
             State.Timer1Fired = true;
-            return TaskDone.Done;
+            return Task.CompletedTask;
         }
     }
 

--- a/test/TestGrains/Listener.cs
+++ b/test/TestGrains/Listener.cs
@@ -18,7 +18,7 @@ namespace TestGrains
             {
                 _receivedCount++;
 
-                return TaskDone.Done;
+                return Task.CompletedTask;
             });
 
             return base.OnActivateAsync();

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestGrains</RootNamespace>
     <AssemblyName>TestGrains</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -31,30 +31,88 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.1.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.2\lib\net451\Orleans.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Orleans, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.5.0\lib\net461\Orleans.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChatMessage.cs" />

--- a/test/TestGrains/TestGrains.csproj
+++ b/test/TestGrains/TestGrains.csproj
@@ -35,8 +35,8 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+    <Reference Include="Orleans, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.2\lib\net451\Orleans.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/TestGrains/app.config
+++ b/test/TestGrains/app.config
@@ -1,19 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/test/TestGrains/app.config
+++ b/test/TestGrains/app.config
@@ -1,19 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/test/TestGrains/packages.config
+++ b/test/TestGrains/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Orleans.Core" version="1.4.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.Core" version="1.4.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net451" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net451" />

--- a/test/TestGrains/packages.config
+++ b/test/TestGrains/packages.config
@@ -1,7 +1,56 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Orleans.Core" version="1.4.2" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Console" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/test/TestInterfaces/TestInterfaces.csproj
+++ b/test/TestInterfaces/TestInterfaces.csproj
@@ -35,8 +35,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+    <Reference Include="Orleans, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.2\lib\net451\Orleans.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/TestInterfaces/TestInterfaces.csproj
+++ b/test/TestInterfaces/TestInterfaces.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestInterfaces</RootNamespace>
     <AssemblyName>TestInterfaces</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/TestInterfaces/TestInterfaces.csproj
+++ b/test/TestInterfaces/TestInterfaces.csproj
@@ -31,30 +31,88 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.1.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.2\lib\net451\Orleans.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Orleans, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.5.0\lib\net461\Orleans.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IChatty.cs" />

--- a/test/TestInterfaces/app.config
+++ b/test/TestInterfaces/app.config
@@ -1,19 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/test/TestInterfaces/app.config
+++ b/test/TestInterfaces/app.config
@@ -1,19 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0"/>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/test/TestInterfaces/packages.config
+++ b/test/TestInterfaces/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Orleans.Core" version="1.4.0" targetFramework="net451" />
+  <package id="Microsoft.Orleans.Core" version="1.4.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net451" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net451" />

--- a/test/TestInterfaces/packages.config
+++ b/test/TestInterfaces/packages.config
@@ -1,7 +1,56 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Orleans.Core" version="1.4.2" targetFramework="net451" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.Orleans.Core" version="1.5.0" targetFramework="net461" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net461" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net451" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Console" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net451" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This PR supersedes #13 and updates the test kit to work with Orleans v 1.5.

Orleans v1.5 makes `GrainCreator`, used by the test kit to instantiate grains, as `internal` meaning it cannot be used. I raised an issue on the Orleans repository about alternatives and was direct to [this thread](https://github.com/dotnet/orleans/issues/3086). The short answers seems to be that best way of unit testing a grain is to accept `IGrainRuntime` and `IGrainIdentity` in the constructor and let Orleans inject them for you in production. 

For the test kit this would mean either implementing some kind of primitive DI or using a container in conjunction with `TestServiceProvider`. The route of least resistance here seemed to be to create a `TestGrainCreator` type that mirrors the functionality of the internal `GrainCreator` using reflection. It is not pretty nor particularly robust, but the tests all pass. 

I'm happy to update the PR if anyone can suggest a better way of doing this? 