### PR TITLE
Add ability to supply a service instance

### DIFF
--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -207,6 +207,12 @@ namespace Orleans.TestKit
 
         public Mock<T> AddServiceProbe<T>() where T : class
             => ServiceProvider.AddServiceProbe<T>();
+        
+        public Mock<T> AddServiceProbe<T>(Mock<T> mock) where T : class
+            => ServiceProvider.AddServiceProbe(mock);
+
+        public T AddService<T>(T instance) where T : class
+            => ServiceProvider.AddService(instance);
 
         #endregion
 

--- a/test/OrleansTestKit.Tests/ServiceProbeTests.cs
+++ b/test/OrleansTestKit.Tests/ServiceProbeTests.cs
@@ -59,7 +59,7 @@ namespace Orleans.TestKit.Tests
             dateServiceMock.Setup(i => i.GetCurrentDate())
                 .ReturnsAsync(() => date);
 
-            Silo.ServiceProvider.AddService(dateServiceMock.Object);
+            Silo.AddService(dateServiceMock.Object);
 
             var grain = Silo.CreateGrain<HelloGrainWithServiceDependency>(10);
 

--- a/test/OrleansTestKit.Tests/ServiceProbeTests.cs
+++ b/test/OrleansTestKit.Tests/ServiceProbeTests.cs
@@ -47,5 +47,30 @@ namespace Orleans.TestKit.Tests
             Assert.NotNull(reply);
             Assert.Equal($"[{default(DateTime).Date}]: You said: '{greeting}', I say: Hello!", reply);
         }
+        
+        [Fact]
+        public async Task SayHelloTestShouldPrintDateWhenServiceProvided()
+        {
+            // Arrange
+            const string greeting = "Bonjour";
+            var date = DateTime.UtcNow.Date;
+
+            var dateServiceMock = new Mock<IDateTimeService>();
+            dateServiceMock.Setup(i => i.GetCurrentDate())
+                .ReturnsAsync(() => date);
+
+            Silo.ServiceProvider.AddService(dateServiceMock.Object);
+
+            var grain = Silo.CreateGrain<HelloGrainWithServiceDependency>(10);
+
+            // Act
+            var reply = await grain.SayHello(greeting);
+
+            // Assert
+            Assert.NotNull(reply);
+            Assert.Equal($"[{date}]: You said: '{greeting}', I say: Hello!", reply);
+
+            dateServiceMock.Verify(i => i.GetCurrentDate(), Times.Once);
+        }
     }
 }


### PR DESCRIPTION
Sometimes it's is necessary to supply an instance of a service instead of it's mock.