### PR TITLE
Changed to netstandard2.0. Moved all silo extension to Testkit namespace

### DIFF
--- a/src/OrleansTestKit/GrainProbeExtensions.cs
+++ b/src/OrleansTestKit/GrainProbeExtensions.cs
@@ -19,6 +19,7 @@ namespace Orleans.TestKit
 
         public static void AddProbe<T>(this TestKitSilo silo, Func<IGrainIdentity, IMock<T>> factory) where T : class, IGrain
             => silo.GrainFactory.AddProbe<T>(factory);
+            
 
         #endregion Probes
     }

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk"> 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>OrleansTestKit</AssemblyName>
     <RootNamespace>Orleans.TestKit</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -8,7 +8,7 @@
     <Product>OrleansTestKit</Product>
     <Description>A testing framework for Microsoft Orleans that does not use a real silo</Description>
     <Copyright>Copyright ©  2017</Copyright>
-    <Version>0.1.4-beta</Version>
+    <Version>0.1.4-beta2</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/OrleansTestKit/Reminders/ReminderExtensions.cs
+++ b/src/OrleansTestKit/Reminders/ReminderExtensions.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using Orleans.Runtime;
 
-namespace Orleans.TestKit.Reminders
+namespace Orleans.TestKit
 {
     public static class ReminderExtensions
     {

--- a/src/OrleansTestKit/Services/TestServicesExtensions.cs
+++ b/src/OrleansTestKit/Services/TestServicesExtensions.cs
@@ -1,6 +1,6 @@
 using Moq;
 
-namespace Orleans.TestKit.Services
+namespace Orleans.TestKit
 {
     public static class TestServicesExtensions
     {

--- a/src/OrleansTestKit/Storage/StorageExtensions.cs
+++ b/src/OrleansTestKit/Storage/StorageExtensions.cs
@@ -2,7 +2,7 @@ using Orleans;
 using Orleans.TestKit;
 using Orleans.TestKit.Storage;
 
-namespace Orleans.TestKit.Storage
+namespace Orleans.TestKit
 {
     public static class StorageExtensions
     {

--- a/src/OrleansTestKit/Streams/StreamExtensions.cs
+++ b/src/OrleansTestKit/Streams/StreamExtensions.cs
@@ -1,6 +1,7 @@
 using System;
+using Orleans.TestKit.Streams;
 
-namespace Orleans.TestKit.Streams
+namespace Orleans.TestKit
 {
     public static class StreamExtensions
     {

--- a/src/OrleansTestKit/TestGrainCreator.cs
+++ b/src/OrleansTestKit/TestGrainCreator.cs
@@ -15,7 +15,6 @@ namespace Orleans.TestKit
         private readonly IGrainRuntime _runtime;
         private readonly PropertyInfo _runtimeProperty;
         private readonly FieldInfo _identityField;
-        private readonly MethodInfo _setStorageMethod;
 
         public TestGrainCreator(IGrainRuntime runtime, IServiceProvider serviceProvider)
         {

--- a/src/OrleansTestKit/Timers/TimerExtensions.cs
+++ b/src/OrleansTestKit/Timers/TimerExtensions.cs
@@ -1,6 +1,6 @@
 using Orleans.TestKit;
 
-namespace Orleans.TestKit.Timers
+namespace Orleans.TestKit
 {
     public static class TimerExtensions
     {


### PR DESCRIPTION
Change TestKitt project to netstandard2.0. Closes #28 Good catch ;)