### PR TITLE
Cleaned up grain probe api to ensure the key type matches the grain type

### DIFF
--- a/src/OrleansTestKit/GrainProbeExtensions.cs
+++ b/src/OrleansTestKit/GrainProbeExtensions.cs
@@ -6,21 +6,16 @@ namespace Orleans.TestKit
 {
     public static class GrainProbeExtensions
     {
-        #region Probes
-
-        public static Mock<T> AddProbe<T>(this TestKitSilo silo, long id, string classPrefix = null) where T : class, IGrain
+        public static Mock<T> AddProbe<T>(this TestKitSilo silo, long id, string classPrefix = null) where T : class, IGrainWithIntegerKey
             => silo.GrainFactory.AddProbe<T>(new TestGrainIdentity(id), classPrefix);
 
-        public static Mock<T> AddProbe<T>(this TestKitSilo silo, Guid id, string classPrefix = null) where T : class, IGrain
+        public static Mock<T> AddProbe<T>(this TestKitSilo silo, Guid id, string classPrefix = null) where T : class, IGrainWithGuidKey
             => silo.GrainFactory.AddProbe<T>(new TestGrainIdentity(id), classPrefix);
 
-        public static Mock<T> AddProbe<T>(this TestKitSilo silo, string id, string classPrefix = null) where T : class, IGrain
+        public static Mock<T> AddProbe<T>(this TestKitSilo silo, string id, string classPrefix = null) where T : class, IGrainWithStringKey
             => silo.GrainFactory.AddProbe<T>(new TestGrainIdentity(id), classPrefix);
 
         public static void AddProbe<T>(this TestKitSilo silo, Func<IGrainIdentity, IMock<T>> factory) where T : class, IGrain
             => silo.GrainFactory.AddProbe<T>(factory);
-            
-
-        #endregion Probes
     }
 }


### PR DESCRIPTION
Closes #30. Now the probe will ensure that the key argument matches the key type specified in the IGrainWith___Key interface.