### PR TITLE
Add Silo.CreateGrainAsync<T>() support and tests

### DIFF
--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -7,8 +7,8 @@
     <Company>OrleansContrib</Company>
     <Product>OrleansTestKit</Product>
     <Description>A testing framework for Microsoft Orleans that does not use a real silo</Description>
-    <Copyright>Copyright ©  2017</Copyright>
-    <Version>2.0.0</Version>
+    <Copyright>Copyright © 2018</Copyright>
+    <Version>2.1.0</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/OrleansTestKit/TestGrainLifecycle.cs
+++ b/src/OrleansTestKit/TestGrainLifecycle.cs
@@ -24,24 +24,10 @@ namespace Orleans.TestKit
             });
         }
 
-        public void TriggerStart()
-        {
-            var tasks = observers.OrderBy(x => x.Item1).Select(x => x.Item2.OnStart(CancellationToken.None));
-
-            Task.WaitAll(tasks.ToArray(), 1000);
-        }
-
         public Task TriggerStartAsync()
         {
             var tasks = observers.OrderBy(x => x.Item1).Select(x => x.Item2.OnStart(CancellationToken.None));
             return Task.WhenAll(tasks.ToArray());
-        }
-
-        public void TriggerStop()
-        {
-            var tasks = observers.Select(x => x.Item2.OnStop(CancellationToken.None));
-
-            Task.WaitAll(tasks.ToArray(), 1000);
         }
 
         public Task TriggerStopAsync()

--- a/src/OrleansTestKit/TestGrainLifecycle.cs
+++ b/src/OrleansTestKit/TestGrainLifecycle.cs
@@ -31,11 +31,23 @@ namespace Orleans.TestKit
             Task.WaitAll(tasks.ToArray(), 1000);
         }
 
+        public Task TriggerStartAsync()
+        {
+            var tasks = observers.OrderBy(x => x.Item1).Select(x => x.Item2.OnStart(CancellationToken.None));
+            return Task.WhenAll(tasks.ToArray());
+        }
+
         public void TriggerStop()
         {
             var tasks = observers.Select(x => x.Item2.OnStop(CancellationToken.None));
 
             Task.WaitAll(tasks.ToArray(), 1000);
+        }
+
+        public Task TriggerStopAsync()
+        {
+            var tasks = observers.Select(x => x.Item2.OnStop(CancellationToken.None));
+            return Task.WhenAll(tasks.ToArray());
         }
     }
 }

--- a/test/OrleansTestKit.Tests/Grains/StatefulActivationGrain.cs
+++ b/test/OrleansTestKit.Tests/Grains/StatefulActivationGrain.cs
@@ -15,9 +15,10 @@ namespace TestGrains
     {
         private int _activationValue;
 
-        public override async Task OnActivateAsync()
+        public override Task OnActivateAsync()
         {
             _activationValue = this.State.Value;
+            return Task.CompletedTask;
         }
 
         public Task<int> GetStateValue() => Task.FromResult(State.Value);

--- a/test/OrleansTestKit.Tests/Tests/ActivationGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ActivationGrainTests.cs
@@ -15,7 +15,7 @@ namespace Orleans.TestKit.Tests
 
 
             // Act
-            var grain = Silo.CreateGrain<StatefulActivationGrain>(0);
+            var grain = await Silo.CreateGrainAsync<StatefulActivationGrain>(0);
             var value = await grain.GetActivationValue();
 
             // Assert

--- a/test/OrleansTestKit.Tests/Tests/BasicGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/BasicGrainTests.cs
@@ -15,21 +15,6 @@ namespace Orleans.TestKit.Tests
             long id = new Random().Next();
             const string greeting = "Bonjour";
 
-            IHello grain = Silo.CreateGrain<HelloGrain>(id);
-
-            // This will create and call a Hello grain with specified 'id' in one of the test silos.
-            string reply = await grain.SayHello(greeting);
-
-            Assert.NotNull(reply);
-            Assert.Equal($"You said: '{greeting}', I say: Hello!", reply);
-        }
-
-        [Fact]
-        public async Task SiloSayHelloTestAsync()
-        {
-            long id = new Random().Next();
-            const string greeting = "Bonjour";
-
             IHello grain = await Silo.CreateGrainAsync<HelloGrain>(id);
 
             // This will create and call a Hello grain with specified 'id' in one of the test silos.
@@ -40,15 +25,7 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void GrainActivation()
-        {
-            var grain = Silo.CreateGrain<LifecycleGrain>(new Random().Next());
-
-            grain.ActivateCount.Should().Be(1);
-        }
-
-        [Fact]
-        public async Task GrainActivationAsync()
+        public async Task GrainActivation()
         {
             var grain = await Silo.CreateGrainAsync<LifecycleGrain>(new Random().Next());
 
@@ -56,15 +33,7 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void SecondGrainCreated()
-        {
-            Silo.CreateGrain<LifecycleGrain>(new Random().Next());
-
-            Silo.Invoking(s => s.CreateGrain<LifecycleGrain>(new Random().Next())).ShouldThrow<Exception>();
-        }
-
-        [Fact]
-        public async Task SecondGrainCreatedAsync()
+        public async Task SecondGrainCreated()
         {
             await Silo.CreateGrainAsync<LifecycleGrain>(new Random().Next());
 
@@ -73,21 +42,9 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void GrainDeactivation()
+        public async Task GrainDeactivation()
         {
-            var grain = Silo.CreateGrain<LifecycleGrain>(new Random().Next());
-
-            grain.DeactivateCount.Should().Be(0);
-
-            Silo.Deactivate(grain);
-
-            grain.DeactivateCount.Should().Be(1);
-        }
-
-        [Fact]
-        public async Task GrainDeactivationAsync()
-        {
-            var grain = Silo.CreateGrain<LifecycleGrain>(new Random().Next());
+            var grain = await Silo.CreateGrainAsync<LifecycleGrain>(new Random().Next());
 
             grain.DeactivateCount.Should().Be(0);
 
@@ -101,18 +58,6 @@ namespace Orleans.TestKit.Tests
         {
             const int id = int.MaxValue;
 
-            var grain = Silo.CreateGrain<IntegerKeyGrain>(id);
-
-            var key = await grain.GetKey();
-
-            key.Should().Be(id);
-        }
-
-        [Fact]
-        public async Task IntegerKeyGrainAsync()
-        {
-            const int id = int.MaxValue;
-
             var grain = await Silo.CreateGrainAsync<IntegerKeyGrain>(id);
 
             var key = await grain.GetKey();
@@ -122,20 +67,6 @@ namespace Orleans.TestKit.Tests
 
         [Fact]
         public async Task IntegerCompoundKeyGrain()
-        {
-            const int id = int.MaxValue;
-            var ext = "Thing";
-
-            var grain = Silo.CreateGrain<IntegerCompoundKeyGrain>(id, ext);
-
-            var key = await grain.GetKey();
-
-            key.Item1.Should().Be(id);
-            key.Item2.Should().Be(ext);
-        }
-
-        [Fact]
-        public async Task IntegerCompoundKeyGrainAsync()
         {
             const int id = int.MaxValue;
             var ext = "Thing";
@@ -153,18 +84,6 @@ namespace Orleans.TestKit.Tests
         {
             var id = Guid.NewGuid();
 
-            var grain = Silo.CreateGrain<GuidKeyGrain>(id);
-
-            var key = await grain.GetKey();
-
-            key.Should().Be(id);
-        }
-
-        [Fact]
-        public async Task GuidKeyGrainAsync()
-        {
-            var id = Guid.NewGuid();
-
             var grain = await Silo.CreateGrainAsync<GuidKeyGrain>(id);
 
             var key = await grain.GetKey();
@@ -174,20 +93,6 @@ namespace Orleans.TestKit.Tests
 
         [Fact]
         public async Task GuidCompoundKeyGrain()
-        {
-            var id = Guid.NewGuid();
-            var ext = "Thing";
-
-            var grain = Silo.CreateGrain<GuidCompoundKeyGrain>(id, ext);
-
-            var key = await grain.GetKey();
-
-            key.Item1.Should().Be(id);
-            key.Item2.Should().Be(ext);
-        }
-
-        [Fact]
-        public async Task GuidCompoundKeyGrainAsync()
         {
             var id = Guid.NewGuid();
             var ext = "Thing";
@@ -205,18 +110,6 @@ namespace Orleans.TestKit.Tests
         {
             const string id = "TestId";
 
-            var grain = Silo.CreateGrain<StringKeyGrain>(id);
-
-            var key = await grain.GetKey();
-
-            key.Should().Be(id);
-        }
-
-        [Fact]
-        public async Task StringKeyGrainAsync()
-        {
-            const string id = "TestId";
-
             var grain = await Silo.CreateGrainAsync<StringKeyGrain>(id);
 
             var key = await grain.GetKey();
@@ -226,18 +119,6 @@ namespace Orleans.TestKit.Tests
 
         [Fact]
         public async Task StatefulIntegerKeyGrain()
-        {
-            const int id = int.MaxValue;
-
-            var grain = Silo.CreateGrain<StatefulIntegerKeyGrain>(id);
-
-            var key = await grain.GetKey();
-
-            key.Should().Be(id);
-        }
-
-        [Fact]
-        public async Task StatefulIntegerKeyGrainAsync()
         {
             const int id = int.MaxValue;
 
@@ -253,18 +134,6 @@ namespace Orleans.TestKit.Tests
         {
             var id = Guid.NewGuid();
 
-            var grain = Silo.CreateGrain<StatefulGuidKeyGrain>(id);
-
-            var key = await grain.GetKey();
-
-            key.Should().Be(id);
-        }
-
-        [Fact]
-        public async Task StatefulGuidKeyGrainAsync()
-        {
-            var id = Guid.NewGuid();
-
             var grain = await Silo.CreateGrainAsync<StatefulGuidKeyGrain>(id);
 
             var key = await grain.GetKey();
@@ -274,18 +143,6 @@ namespace Orleans.TestKit.Tests
 
         [Fact]
         public async Task StatefulStringKeyGrain()
-        {
-            const string id = "TestId";
-
-            var grain = Silo.CreateGrain<StatefulStringKeyGrain>(id);
-
-            var key = await grain.GetKey();
-
-            key.Should().Be(id);
-        }
-
-        [Fact]
-        public async Task StatefulStringKeyGrainAsync()
         {
             const string id = "TestId";
 

--- a/test/OrleansTestKit.Tests/Tests/BasicGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/BasicGrainTests.cs
@@ -25,9 +25,32 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
+        public async Task SiloSayHelloTestAsync()
+        {
+            long id = new Random().Next();
+            const string greeting = "Bonjour";
+
+            IHello grain = await Silo.CreateGrainAsync<HelloGrain>(id);
+
+            // This will create and call a Hello grain with specified 'id' in one of the test silos.
+            string reply = await grain.SayHello(greeting);
+
+            Assert.NotNull(reply);
+            Assert.Equal($"You said: '{greeting}', I say: Hello!", reply);
+        }
+
+        [Fact]
         public void GrainActivation()
         {
             var grain = Silo.CreateGrain<LifecycleGrain>(new Random().Next());
+
+            grain.ActivateCount.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task GrainActivationAsync()
+        {
+            var grain = await Silo.CreateGrainAsync<LifecycleGrain>(new Random().Next());
 
             grain.ActivateCount.Should().Be(1);
         }
@@ -38,6 +61,15 @@ namespace Orleans.TestKit.Tests
             Silo.CreateGrain<LifecycleGrain>(new Random().Next());
 
             Silo.Invoking(s => s.CreateGrain<LifecycleGrain>(new Random().Next())).ShouldThrow<Exception>();
+        }
+
+        [Fact]
+        public async Task SecondGrainCreatedAsync()
+        {
+            await Silo.CreateGrainAsync<LifecycleGrain>(new Random().Next());
+
+            Func<Task> creatingSecondGrainAsync = async () => await Silo.CreateGrainAsync<LifecycleGrain>(new Random().Next());
+            creatingSecondGrainAsync.ShouldThrow<Exception>();
         }
 
         [Fact]
@@ -53,11 +85,35 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
+        public async Task GrainDeactivationAsync()
+        {
+            var grain = Silo.CreateGrain<LifecycleGrain>(new Random().Next());
+
+            grain.DeactivateCount.Should().Be(0);
+
+            await Silo.DeactivateAsync(grain);
+
+            grain.DeactivateCount.Should().Be(1);
+        }
+
+        [Fact]
         public async Task IntegerKeyGrain()
         {
             const int id = int.MaxValue;
 
             var grain = Silo.CreateGrain<IntegerKeyGrain>(id);
+
+            var key = await grain.GetKey();
+
+            key.Should().Be(id);
+        }
+
+        [Fact]
+        public async Task IntegerKeyGrainAsync()
+        {
+            const int id = int.MaxValue;
+
+            var grain = await Silo.CreateGrainAsync<IntegerKeyGrain>(id);
 
             var key = await grain.GetKey();
 
@@ -79,11 +135,37 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
+        public async Task IntegerCompoundKeyGrainAsync()
+        {
+            const int id = int.MaxValue;
+            var ext = "Thing";
+
+            var grain = await Silo.CreateGrainAsync<IntegerCompoundKeyGrain>(id, ext);
+
+            var key = await grain.GetKey();
+
+            key.Item1.Should().Be(id);
+            key.Item2.Should().Be(ext);
+        }
+
+        [Fact]
         public async Task GuidKeyGrain()
         {
             var id = Guid.NewGuid();
 
             var grain = Silo.CreateGrain<GuidKeyGrain>(id);
+
+            var key = await grain.GetKey();
+
+            key.Should().Be(id);
+        }
+
+        [Fact]
+        public async Task GuidKeyGrainAsync()
+        {
+            var id = Guid.NewGuid();
+
+            var grain = await Silo.CreateGrainAsync<GuidKeyGrain>(id);
 
             var key = await grain.GetKey();
 
@@ -105,11 +187,37 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
+        public async Task GuidCompoundKeyGrainAsync()
+        {
+            var id = Guid.NewGuid();
+            var ext = "Thing";
+
+            var grain = await Silo.CreateGrainAsync<GuidCompoundKeyGrain>(id, ext);
+
+            var key = await grain.GetKey();
+
+            key.Item1.Should().Be(id);
+            key.Item2.Should().Be(ext);
+        }
+
+        [Fact]
         public async Task StringKeyGrain()
         {
             const string id = "TestId";
 
             var grain = Silo.CreateGrain<StringKeyGrain>(id);
+
+            var key = await grain.GetKey();
+
+            key.Should().Be(id);
+        }
+
+        [Fact]
+        public async Task StringKeyGrainAsync()
+        {
+            const string id = "TestId";
+
+            var grain = await Silo.CreateGrainAsync<StringKeyGrain>(id);
 
             var key = await grain.GetKey();
 
@@ -129,6 +237,18 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
+        public async Task StatefulIntegerKeyGrainAsync()
+        {
+            const int id = int.MaxValue;
+
+            var grain = await Silo.CreateGrainAsync<StatefulIntegerKeyGrain>(id);
+
+            var key = await grain.GetKey();
+
+            key.Should().Be(id);
+        }
+
+        [Fact]
         public async Task StatefulGuidKeyGrain()
         {
             var id = Guid.NewGuid();
@@ -141,11 +261,35 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
+        public async Task StatefulGuidKeyGrainAsync()
+        {
+            var id = Guid.NewGuid();
+
+            var grain = await Silo.CreateGrainAsync<StatefulGuidKeyGrain>(id);
+
+            var key = await grain.GetKey();
+
+            key.Should().Be(id);
+        }
+
+        [Fact]
         public async Task StatefulStringKeyGrain()
         {
             const string id = "TestId";
 
             var grain = Silo.CreateGrain<StatefulStringKeyGrain>(id);
+
+            var key = await grain.GetKey();
+
+            key.Should().Be(id);
+        }
+
+        [Fact]
+        public async Task StatefulStringKeyGrainAsync()
+        {
+            const string id = "TestId";
+
+            var grain = await Silo.CreateGrainAsync<StatefulStringKeyGrain>(id);
 
             var key = await grain.GetKey();
 

--- a/test/OrleansTestKit.Tests/Tests/DIGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/DIGrainTests.cs
@@ -11,36 +11,17 @@ namespace Orleans.TestKit.Tests
     public class DIGrainTests : TestKitBase
     {
         [Fact]
-        public void CreateGrainWithService()
-        {
-            var grain = Silo.CreateGrain<DIGrain>(Guid.NewGuid());
-
-            grain.Service.Should().NotBeNull();
-        }
-
-        [Fact]
-        public async Task CreateGrainWithServiceAsync()
+        public async Task CreateGrainWithService()
         {
             var grain = await Silo.CreateGrainAsync<DIGrain>(Guid.NewGuid());
 
             grain.Service.Should().NotBeNull();
         }
 
+        
+        
         [Fact]
-        public void SetupGrainService()
-        {
-            var mockSvc = new Mock<IDIService>();
-            mockSvc.Setup(x => x.GetValue()).Returns(true);
-
-            Silo.ServiceProvider.AddServiceProbe(mockSvc);
-            var grain = Silo.CreateGrain<DIGrain>(Guid.NewGuid());
-
-            grain.GetServiceValue().Should().BeTrue();
-            mockSvc.Verify(x => x.GetValue(), Times.Once);
-        }
-
-        [Fact]
-        public async Task SetupGrainServiceAsync()
+        public async Task SetupGrainService()
         {
             var mockSvc = new Mock<IDIService>();
             mockSvc.Setup(x => x.GetValue()).Returns(true);

--- a/test/OrleansTestKit.Tests/Tests/DIGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/DIGrainTests.cs
@@ -19,6 +19,14 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
+        public async Task CreateGrainWithServiceAsync()
+        {
+            var grain = await Silo.CreateGrainAsync<DIGrain>(Guid.NewGuid());
+
+            grain.Service.Should().NotBeNull();
+        }
+
+        [Fact]
         public void SetupGrainService()
         {
             var mockSvc = new Mock<IDIService>();
@@ -26,6 +34,19 @@ namespace Orleans.TestKit.Tests
 
             Silo.ServiceProvider.AddServiceProbe(mockSvc);
             var grain = Silo.CreateGrain<DIGrain>(Guid.NewGuid());
+
+            grain.GetServiceValue().Should().BeTrue();
+            mockSvc.Verify(x => x.GetValue(), Times.Once);
+        }
+
+        [Fact]
+        public async Task SetupGrainServiceAsync()
+        {
+            var mockSvc = new Mock<IDIService>();
+            mockSvc.Setup(x => x.GetValue()).Returns(true);
+
+            Silo.ServiceProvider.AddServiceProbe(mockSvc);
+            var grain = await Silo.CreateGrainAsync<DIGrain>(Guid.NewGuid());
 
             grain.GetServiceValue().Should().BeTrue();
             mockSvc.Verify(x => x.GetValue(), Times.Once);

--- a/test/OrleansTestKit.Tests/Tests/DeactivationGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/DeactivationGrainTests.cs
@@ -12,7 +12,7 @@ namespace Orleans.TestKit.Tests
         public async Task ShouldCallDeactivateOnIdle()
         {
             // Arrange
-            var grain = Silo.CreateGrain<DeactivationGrain>(0);
+            var grain = await Silo.CreateGrainAsync<DeactivationGrain>(0);
 
             // Act
             await grain.DeactivateOnIdle();
@@ -25,7 +25,7 @@ namespace Orleans.TestKit.Tests
         public async Task ShouldCallDelayDeactivation()
         {
             // Arrange
-            var grain = Silo.CreateGrain<DeactivationGrain>(0);
+            var grain = await Silo.CreateGrainAsync<DeactivationGrain>(0);
             var timeSpan = TimeSpan.FromSeconds(5);
 
             // Act

--- a/test/OrleansTestKit.Tests/Tests/GrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/GrainProbeTests.cs
@@ -14,7 +14,7 @@ namespace Orleans.TestKit.Tests
         [Fact]
         public async Task SetupProbe()
         {
-            IPing grain = Silo.CreateGrain<PingGrain>(1);
+            IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             var pong = Silo.AddProbe<IPong>(22);
 
@@ -26,7 +26,7 @@ namespace Orleans.TestKit.Tests
         [Fact]
         public async Task SetupCompoundProbe()
         {
-            IPing grain = Silo.CreateGrain<PingGrain>(1);
+            IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             var pong = Silo.AddProbe<IPongCompound>(44, keyExtension: "Test");
 
@@ -36,18 +36,18 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void MissingProbe()
+        public async Task MissingProbe()
         {
-            IPing grain = Silo.CreateGrain<PingGrain>(1);
+            IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             //There should not be an exception, since we are using loose grain generation
             grain.Invoking(p => p.Ping()).ShouldNotThrow();
         }
 
         [Fact]
-        public void InvalidProbe()
+        public async Task InvalidProbe()
         {
-            IPing grain = Silo.CreateGrain<PingGrain>(1);
+            IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             //This uses the wrong id for the IPong since this is hard coded within PingGrain
             var pong = Silo.AddProbe<IPong>(0);
@@ -58,9 +58,9 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void InvalidProbeType()
+        public async Task InvalidProbeType()
         {
-            IPing grain = Silo.CreateGrain<PingGrain>(1);
+            IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             //This correct id, but a different grain type
             var pong = Silo.AddProbe<IPong2>(22);
@@ -135,7 +135,7 @@ namespace Orleans.TestKit.Tests
 
             this.Silo.AddProbe<IPong>(identity => pong);
 
-            var grain = this.Silo.CreateGrain<PingGrain>(1);
+            var grain = await this.Silo.CreateGrainAsync<PingGrain>(1);
 
             await grain.Ping();
 
@@ -148,7 +148,7 @@ namespace Orleans.TestKit.Tests
             Silo.AddProbe<IDevice>("Android", "TestGrains.DeviceAndroidGrain");
             Silo.AddProbe<IDevice>("IOS", "TestGrains.DeviceIosGrain");
 
-            var managerGrain = this.Silo.CreateGrain<DeviceManagerGrain>(0);
+            var managerGrain = await this.Silo.CreateGrainAsync<DeviceManagerGrain>(0);
             var iosGrain = await managerGrain.GetDeviceGrain("IOS");
             var androidGrain = await managerGrain.GetDeviceGrain("Android");
 

--- a/test/OrleansTestKit.Tests/Tests/LoggerTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/LoggerTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using TestGrains;
 using TestInterfaces;
 using Xunit;
@@ -16,21 +17,21 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void ConsoleLog()
+        public async Task ConsoleLog()
         {
             const string greeting = "Bonjour";
 
-            IHello grain = Silo.CreateGrain<HelloGrain>(1);
+            IHello grain = await Silo.CreateGrainAsync<HelloGrain>(1);
 
             grain.Invoking(g => g.SayHello(greeting)).ShouldNotThrow();
         }
 
         [Fact]
-        public void XUnitLog()
+        public async Task XUnitLog()
         {
             const string greeting = "Bonjour";
 
-            IHello grain = Silo.CreateGrain<HelloGrain>(2);
+            IHello grain = await Silo.CreateGrainAsync<HelloGrain>(2);
 
             grain.Invoking(g => g.SayHello(greeting)).ShouldNotThrow();
         }

--- a/test/OrleansTestKit.Tests/Tests/ReminderTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ReminderTests.cs
@@ -15,7 +15,7 @@ namespace Orleans.TestKit.Tests
         public async Task RegisterReminder()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloReminders>(0);
+            var grain = await Silo.CreateGrainAsync<HelloReminders>(0);
 
             const string reminderName = "abc123";
             var due = TimeSpan.Zero;
@@ -32,7 +32,7 @@ namespace Orleans.TestKit.Tests
         public async Task UnRegisterReminder()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloReminders>(0);
+            var grain = await Silo.CreateGrainAsync<HelloReminders>(0);
 
             const string reminderName = "abc123";
             var due = TimeSpan.Zero;
@@ -50,7 +50,7 @@ namespace Orleans.TestKit.Tests
         public async Task TriggerUnRegisterReminder()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloReminders>(0);
+            var grain = await Silo.CreateGrainAsync<HelloReminders>(0);
 
             const string reminderName = "abc123";
             var due = TimeSpan.Zero;
@@ -69,7 +69,7 @@ namespace Orleans.TestKit.Tests
         public async Task TriggerAllReminders()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloReminders>(0);
+            var grain = await Silo.CreateGrainAsync<HelloReminders>(0);
 
             const string reminderName1 = "abc123";
             const string reminderName2 = "123";
@@ -90,7 +90,7 @@ namespace Orleans.TestKit.Tests
         public async Task TriggerSingleReminderOnce()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloReminders>(0);
+            var grain = await Silo.CreateGrainAsync<HelloReminders>(0);
 
             const string reminderName = "abc123";
 
@@ -108,7 +108,7 @@ namespace Orleans.TestKit.Tests
         public async Task TriggerSingleReminderMultiple()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloReminders>(0);
+            var grain = await Silo.CreateGrainAsync<HelloReminders>(0);
 
             const string reminderName = "abc123";
 
@@ -127,7 +127,7 @@ namespace Orleans.TestKit.Tests
         public async Task TriggerUnknownReminder()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloReminders>(0);
+            var grain = await Silo.CreateGrainAsync<HelloReminders>(0);
 
             await grain.RegisterReminder("a", TimeSpan.Zero, TimeSpan.MaxValue);
 

--- a/test/OrleansTestKit.Tests/Tests/ServiceProbeTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ServiceProbeTests.cs
@@ -21,7 +21,7 @@ namespace Orleans.TestKit.Tests
             dateServiceMock.Setup(i => i.GetCurrentDate())
                     .ReturnsAsync(() => date);
 
-            var grain = Silo.CreateGrain<HelloGrainWithServiceDependency>(10);
+            var grain = await Silo.CreateGrainAsync<HelloGrainWithServiceDependency>(10);
 
             // Act
             var reply = await grain.SayHello(greeting);
@@ -39,7 +39,7 @@ namespace Orleans.TestKit.Tests
             // Arrange
             const string greeting = "Bonjour";
 
-            var grain = Silo.CreateGrain<HelloGrainWithServiceDependency>(10);
+            var grain = await Silo.CreateGrainAsync<HelloGrainWithServiceDependency>(10);
 
             // Act
             var reply = await grain.SayHello(greeting);
@@ -62,7 +62,7 @@ namespace Orleans.TestKit.Tests
 
             Silo.AddService(dateServiceMock.Object);
 
-            var grain = Silo.CreateGrain<HelloGrainWithServiceDependency>(10);
+            var grain = await Silo.CreateGrainAsync<HelloGrainWithServiceDependency>(10);
 
             // Act
             var reply = await grain.SayHello(greeting);

--- a/test/OrleansTestKit.Tests/Tests/StorageTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageTests.cs
@@ -17,7 +17,7 @@ namespace Orleans.TestKit.Tests
             const string greeting1 = "Bonjour";
             const string greeting2 = "Hei";
 
-            var grain = Silo.CreateGrain<HelloArchiveGrain>(id);
+            var grain = await Silo.CreateGrainAsync<HelloArchiveGrain>(id);
 
             // This will directly call the grain under test.
             await grain.SayHello(greeting1);
@@ -38,7 +38,7 @@ namespace Orleans.TestKit.Tests
             long id = new Random().Next();
             const string greeting = "Bonjour";
 
-            var grain = Silo.CreateGrain<HelloArchiveGrain>(id);
+            var grain = await Silo.CreateGrainAsync<HelloArchiveGrain>(id);
 
             // This will directly call the grain under test.
             await grain.SayHello(greeting);

--- a/test/OrleansTestKit.Tests/Tests/StreamTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StreamTests.cs
@@ -12,7 +12,7 @@ namespace Orleans.TestKit.Tests
         [Fact]
         public async Task GrainSentMessages()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
 
@@ -25,9 +25,9 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void LazyStreamProvider()
+        public async Task LazyStreamProvider()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             const string msg = "Hello Chat";
 
@@ -36,11 +36,11 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void LazyStreamProviderStrict()
+        public async Task LazyStreamProviderStrict()
         {
             Silo.Options.StrictStreamProbes = true;
 
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             const string msg = "Hello Chat";
 
@@ -51,7 +51,7 @@ namespace Orleans.TestKit.Tests
         [Fact]
         public async Task IncorrectVerifyMessage()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
 
@@ -63,9 +63,9 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void IncorrectProbeId()
+        public async Task IncorrectProbeId()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             Silo.AddStreamProbe<ChatMessage>(Guid.NewGuid(), null);
 
@@ -75,9 +75,9 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void IncorrectProbeNamespace()
+        public async Task IncorrectProbeNamespace()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             Silo.AddStreamProbe<ChatMessage>(Guid.Empty, "Wrong");
 
@@ -87,11 +87,11 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void GrainIsSubscribed()
+        public async Task GrainIsSubscribed()
         {
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
 
-            Silo.CreateGrain<Listener>(1);
+            await Silo.CreateGrainAsync<Listener>(1);
 
             stream.Subscribed.Should().Be(1);
         }
@@ -101,7 +101,7 @@ namespace Orleans.TestKit.Tests
         {
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
 
-            var grain = Silo.CreateGrain<Listener>(1);
+            var grain = await Silo.CreateGrainAsync<Listener>(1);
 
             await stream.OnNextAsync(new ChatMessage("Ding"));
 

--- a/test/OrleansTestKit.Tests/Tests/StrictGrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StrictGrainProbeTests.cs
@@ -20,7 +20,7 @@ namespace Orleans.TestKit.Tests
         [Fact]
         public async Task SetupProbe()
         {
-            var grain = Silo.CreateGrain<PingGrain>(1);
+            var grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             var pong = Silo.AddProbe<IPong>(22);
 
@@ -30,17 +30,17 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void MissingProbe()
+        public async Task MissingProbe()
         {
-            IPing grain = Silo.CreateGrain<PingGrain>(1);
+            IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             grain.Invoking(p => p.Ping()).ShouldThrowExactly<Exception>();
         }
 
         [Fact]
-        public void InvalidProbe()
+        public async Task InvalidProbe()
         {
-            IPing grain = Silo.CreateGrain<PingGrain>(1);
+            IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             //This uses the wrong id for the IPong since this is hard coded within PingGrain
             var pong = Silo.AddProbe<IPong>(0);
@@ -51,9 +51,9 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void InvalidProbeType()
+        public async Task InvalidProbeType()
         {
-            IPing grain = Silo.CreateGrain<PingGrain>(1);
+            IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             //This uses the correct id, but the wrong grain type
             var pong = Silo.AddProbe<IPong2>(22);

--- a/test/OrleansTestKit.Tests/Tests/StrictStreamTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StrictStreamTests.cs
@@ -17,7 +17,7 @@ namespace Orleans.TestKit.Tests
         [Fact]
         public async Task GrainSentMessages()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
 
@@ -32,7 +32,7 @@ namespace Orleans.TestKit.Tests
         [Fact]
         public async Task IncorrectVerifyMessage()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
 
@@ -44,9 +44,9 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void IncorrectProbeId()
+        public async Task IncorrectProbeId()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             Silo.AddStreamProbe<ChatMessage>(Guid.NewGuid(), null);
 
@@ -56,9 +56,9 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void IncorrectProbeNamespace()
+        public async Task IncorrectProbeNamespace()
         {
-            var chatty = Silo.CreateGrain<Chatty>(4);
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
 
             Silo.AddStreamProbe<ChatMessage>(Guid.Empty, "Wrong");
 
@@ -68,11 +68,11 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void GrainIsSubscribed()
+        public async Task GrainIsSubscribed()
         {
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
 
-            Silo.CreateGrain<Listener>(1);
+            await Silo.CreateGrainAsync<Listener>(1);
 
             stream.Subscribed.Should().Be(1);
         }
@@ -82,7 +82,7 @@ namespace Orleans.TestKit.Tests
         {
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
 
-            var grain = Silo.CreateGrain<Listener>(1);
+            var grain = await Silo.CreateGrainAsync<Listener>(1);
 
             await stream.OnNextAsync(new ChatMessage("Ding"));
 

--- a/test/OrleansTestKit.Tests/Tests/TimerTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/TimerTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using Orleans.TestKit.Storage;
 using Orleans.TestKit.Timers;
 using TestGrains;
@@ -9,10 +10,10 @@ namespace Orleans.TestKit.Tests
     public class TimerTests : TestKitBase
     {
         [Fact]
-        public void ShouldFireAllTimers()
+        public async Task ShouldFireAllTimers()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloTimers>(0);
+            var grain = await Silo.CreateGrainAsync<HelloTimers>(0);
 
             // Act
             Silo.FireAllTimers();
@@ -24,10 +25,10 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void ShouldFireFirstTimer()
+        public async Task ShouldFireFirstTimer()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloTimers>(0);
+            var grain = await Silo.CreateGrainAsync<HelloTimers>(0);
 
             // Act
             Silo.FireTimer(0);
@@ -39,10 +40,10 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
-        public void ShouldFireSecondTimer()
+        public async Task ShouldFireSecondTimer()
         {
             // Arrange
-            var grain = Silo.CreateGrain<HelloTimers>(0);
+            var grain = await Silo.CreateGrainAsync<HelloTimers>(0);
 
             // Act
             Silo.FireTimer(1);


### PR DESCRIPTION
When running the OrleansTestKit-based tests for a project in a VSTS (Visual Studio Online) build/release pipeline, we were getting failed streamprobe subscription count assertions. The tests pass locally on our dev machines, but when debugging with breakpoints we were finally able to recreate a similar problem.  Specifically we were seeing Subscription count assertions for registered StreamProbes would be wrong based on where we set breakpoints and how long we waited to proceed debugging. We speculated that `OnActivatedAsync` was an asynchronous method that was getting kicked off by `Silo.CreateGrain<T>()` (a non-asynchronous method).

Today I spent some time and found what I think is the "smoking gun" for this behavior:
```
Task.WaitAll(tasks.ToArray(), 1000);
```
in TestGrainLifecycle.cs

Rather than break any existing code, this PR introduces a new `Silo.CreateGrainAsync<T>()` call that should allow the TestGrainLifecycle work to deterministically complete (rather than return immediately while the async work is occurring in the background). Thus any assertions immediately thereafter will have a much better chance of happening *after* the grain activation has completed (unless I have missed something).

I encourage any feedback/suggestions, and made a good faith effort to cover `CreateGrainAsync` with tests similar to those of `CreateGrain`. 

Thanks for the time and effort making this TestKit, it really fills a need for us, and if we can squash the variable behavior across build/test hosts, we will be in great shape.

Thanks for your time and consideration!
Elliott
