### PR TITLE
Fixed `TimerRegistry` property name typo

### DIFF
--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -45,7 +46,14 @@ namespace Orleans.TestKit
         /// <summary>
         /// Manages all test silo timers.
         /// </summary>
-        public TestTimerRegistry TimerReistry { get; }
+        public TestTimerRegistry TimerRegistry { get; }
+
+        /// <summary>
+        /// Manages all test silo timers.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use TestKitSilo.TimerRegistry")]
+        public TestTimerRegistry TimerReistry => this.TimerRegistry;
 
         /// <summary>
         /// Manages all test silo reminders
@@ -79,7 +87,7 @@ namespace Orleans.TestKit
 
             StorageManager = new StorageManager();
 
-            TimerReistry = new TestTimerRegistry();
+            TimerRegistry = new TestTimerRegistry();
 
             ReminderRegistry = new TestReminderRegistry();
 
@@ -87,7 +95,7 @@ namespace Orleans.TestKit
 
             ServiceProvider.AddService<IKeyedServiceCollection<string, IStreamProvider>>(StreamProviderManager);
 
-            _grainRuntime = new TestGrainRuntime(GrainFactory, TimerReistry, ReminderRegistry, ServiceProvider, StorageManager);
+            _grainRuntime = new TestGrainRuntime(GrainFactory, TimerRegistry, ReminderRegistry, ServiceProvider, StorageManager);
 
             _grainCreator = new TestGrainCreator(_grainRuntime, ServiceProvider);
         }

--- a/src/OrleansTestKit/Timers/TimerExtensions.cs
+++ b/src/OrleansTestKit/Timers/TimerExtensions.cs
@@ -1,17 +1,27 @@
-﻿using Orleans.TestKit;
+﻿using System;
 
 namespace Orleans.TestKit
 {
     public static class TimerExtensions
     {
-        public static void FireTimer(this TestKitSilo silo, int index)
-        {
-            silo.TimerReistry.Fire(index);
-        }
-
         public static void FireAllTimers(this TestKitSilo silo)
         {
-            silo.TimerReistry.FireAll();
+            if (silo == null)
+            {
+                throw new ArgumentNullException(nameof(silo));
+            }
+
+            silo.TimerRegistry.FireAll();
+        }
+
+        public static void FireTimer(this TestKitSilo silo, int index)
+        {
+            if (silo == null)
+            {
+                throw new ArgumentNullException(nameof(silo));
+            }
+
+            silo.TimerRegistry.Fire(index);
         }
     }
 }


### PR DESCRIPTION
Thanks to @srollinet in #51 for pointing out a silly typo. The `TimerReistry` property was spelled incorrectly. This change retains the misspelled property for backward compatibility but marks it as `Obsolete`. References should be updated to use the corrected `TimerRegistry` property.