### PR TITLE
Change `TestReminderRegistry` to behave more like the runtime reminder registry

### DIFF
--- a/src/OrleansTestKit/Reminders/TestReminderRegistry.cs
+++ b/src/OrleansTestKit/Reminders/TestReminderRegistry.cs
@@ -25,7 +25,7 @@ namespace Orleans.TestKit.Reminders
         public async Task<IGrainReminder> GetReminder(string reminderName) {
             await Mock.Object.GetReminder(reminderName);
 
-            return _reminders[reminderName] as IGrainReminder;
+            return !_reminders.TryGetValue(reminderName, out var reminder) ? null : reminder;
         }
         public async Task<List<IGrainReminder>> GetReminders() {
             await Mock.Object.GetReminders();

--- a/test/OrleansTestKit.Tests/Grains/HelloReminders.cs
+++ b/test/OrleansTestKit.Tests/Grains/HelloReminders.cs
@@ -23,7 +23,10 @@ namespace TestGrains
         {
             var reminder = await this.GetReminder(reminderName);
 
-            await this.UnregisterReminder(reminder);
+            if (reminder != null)
+            {
+                await this.UnregisterReminder(reminder);
+            }
         }
     }
 }

--- a/test/OrleansTestKit.Tests/Tests/ReminderTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ReminderTests.cs
@@ -138,5 +138,18 @@ namespace Orleans.TestKit.Tests
             f.Should().Throw<Exception>();
             grain.FiredReminders.Count.Should().Be(0);
         }
+
+        [Fact]
+        public async Task UnregisterUnknownReminder()
+        {
+            // Arrange
+            var grain = await Silo.CreateGrainAsync<HelloReminders>(0);
+
+            // Act
+            await grain.UnregisterReminder("a");
+
+            // Assert
+            Silo.ReminderRegistry.Mock.Verify(v => v.GetReminder("a"), Times.Once);
+        }
     }
 }


### PR DESCRIPTION
Fixed #45. Thanks to @christiansparre for the fix!

The `TestReminderRegistry` would throw a `KeyNotFoundException` while the runtime registry returns `null` if the reminder does not exist making testing non existent reminder behavior difficult.

This makes the `TestReminderRegistry` return `null` if the dictionary does not
contain a reminder with the provided reminder name.

There is also some minor changes to the `HelloReminders` test grain and a test of the changed behavior.