### PR TITLE
Updated NuGet dependencies

### DIFF
--- a/OrleansTestKit.sln
+++ b/OrleansTestKit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.539
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.452
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{54C04CF7-7044-46E0-BC24-2A992F028557}"
 EndProject

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -23,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.3.2" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.3.2" />
     <PackageReference Include="Moq" Version="4.10.1" />
   </ItemGroup>
 

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="15.9.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.1" />
-    <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="2.3.0" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Legacy" Version="2.3.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This updates to Orleans 2.3.2.

This _should_ fix #59, but only by forcing projects to update to Orleans 2.3.2. Note that there currently is no good solution for releasing OrleansTestKit packages in lock-step with Orleans. Additionally, there's not really a great solution to having a release on NuGet for every incremental version of Orleans. If this is a concern for your project, I'm definitely open to a discussion/potential solution.