### PR TITLE
Fix unsubscribing from streams during OnNextAsync callback

### DIFF
--- a/src/OrleansTestKit/Streams/TestStream.cs
+++ b/src/OrleansTestKit/Streams/TestStream.cs
@@ -82,14 +82,14 @@ namespace Orleans.TestKit.Streams
         {
             Sends++;
             _mockStream.Object.OnNextAsync(item, token);
-            return Task.WhenAll(_observers.Select(o => o.OnNextAsync(item, token)));
+            return Task.WhenAll(_observers.ToList().Select(o => o.OnNextAsync(item, token)));
         }
 
         public Task OnCompletedAsync() =>
-            Task.WhenAll(_observers.Select(o => o.OnCompletedAsync()));
+            Task.WhenAll(_observers.ToList().Select(o => o.OnCompletedAsync()));
 
         public Task OnErrorAsync(Exception ex) =>
-            Task.WhenAll(_observers.Select(o => o.OnErrorAsync(ex)));
+            Task.WhenAll(_observers.ToList().Select(o => o.OnErrorAsync(ex)));
 
         public Task OnNextBatchAsync(IEnumerable<T> batch, StreamSequenceToken token = null) =>
             throw new NotImplementedException();

--- a/src/OrleansTestKit/Timers/TestTimerRegistry.cs
+++ b/src/OrleansTestKit/Timers/TestTimerRegistry.cs
@@ -31,7 +31,7 @@ namespace Orleans.TestKit.Timers
 
         public async Task FireAllAsync()
         {
-            foreach (var testTimer in _timers.ToArray())
+            foreach (var testTimer in new List<TestTimer>(_timers))
             {
                 await testTimer.FireAsync().ConfigureAwait(false);
             }

--- a/test/OrleansTestKit.Tests/Tests/StreamTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StreamTests.cs
@@ -118,6 +118,27 @@ namespace Orleans.TestKit.Tests
         }
 
         [Fact]
+        public async Task GrainIsUnsubscribed()
+        {
+            var stream = Silo.AddStreamProbe<(string Message, int Id)>(Guid.Empty, null);
+
+            var chatty = await Silo.CreateGrainAsync<Chatty>(4);
+            await chatty.Subscribe();
+
+            stream.Subscribed.Should().Be(1);
+
+            const string msg = "Goodbye";
+            const int id = 3;
+            await stream.OnNextAsync((msg, id));
+
+            stream.Sends.Should().Be(1);
+            stream.VerifySend(m => m.Message == msg);
+            stream.VerifySend(m => m.Id == id);
+
+            stream.Subscribed.Should().Be(0);
+        }
+
+        [Fact]
         public async Task GrainGetAllSubscriptionHandles()
         {
             var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);


### PR DESCRIPTION
Fixes #84. The mock stream provider will first copy the list of subscriptions before invoking the OnNextAsync callbacks to ensure the iterator doesn't throw an `InvalidOperationException`.