### PR TITLE
Update Microsoft.Orleans.OrleansRuntime to version 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ When run within a test kit environment, code that calls the `GetPrimaryKey` exte
 
 See [issue #47](https://github.com/OrleansContrib/OrleansTestKit/issues/47) for a discussion and references to upstream issues.
 
+Grains with States that do not have a parameterless constructor are not supported by the default IStorage implementation.
+
 ## Build Artifacts
 
 The build artifacts for tagged commits are published to [NuGet](http://www.nuget.org/packages/OrleansTestKit/) and copied to [GitHub Releases](https://github.com/OrleansContrib/OrleansTestKit/releases).

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Authors>dsarfati,seniorquico</Authors>
-    <Copyright>Copyright © 2017-2019 Daniel Sarfati</Copyright>
+    <Copyright>Copyright © 2017-2020 Daniel Sarfati</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageDescription>A unit test toolkit for Microsoft Orleans that does not require a real silo. Instead, tests are run with a mock silo.</PackageDescription>
@@ -15,7 +15,7 @@
     <PackageTags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET Test Testing</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>3.0.1</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/OrleansTestKit/Storage/StorageManager.cs
+++ b/src/OrleansTestKit/Storage/StorageManager.cs
@@ -6,7 +6,7 @@ namespace Orleans.TestKit.Storage
     {
         private object _storage;
 
-        public IStorage<TState> GetStorage<TState>() where TState : new()
+        public IStorage<TState> GetStorage<TState>()
         {
             if (_storage == null)
             {

--- a/src/OrleansTestKit/TestGrainActivationContext.cs
+++ b/src/OrleansTestKit/TestGrainActivationContext.cs
@@ -23,8 +23,5 @@ namespace Orleans.TestKit
         public IDictionary<object, object> Items => throw new NotImplementedException();
 
         public IGrainLifecycle ObservableLifecycle { get; set; }
-
-        [SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations")]
-        public IMultiClusterRegistrationStrategy RegistrationStrategy => throw new NotImplementedException();
     }
 }

--- a/src/OrleansTestKit/TestGrainRuntime.cs
+++ b/src/OrleansTestKit/TestGrainRuntime.cs
@@ -57,8 +57,7 @@ namespace Orleans.TestKit
             Mock.Object.DelayDeactivation(grain, timeSpan);
         }
 
-        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain)
-            where TGrainState : new() =>
+        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) =>
             _storageManager.GetStorage<TGrainState>();
     }
 }

--- a/test/OrleansTestKit.Tests/Grains/StatefulNonNewActivationGrain.cs
+++ b/test/OrleansTestKit.Tests/Grains/StatefulNonNewActivationGrain.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans;
+using TestInterfaces;
+
+namespace TestGrains
+{
+    public interface IStatefulUnsupportedActivationGrain : IGrainWithIntegerKey
+    {
+        Task<int> GetActivationValue();
+
+        Task<int> GetStateValue();
+    }
+    public sealed class StatefulUnsupportedActivationGrain : Grain<StatefulNonSupportedActivationGrainState>, IStatefulUnsupportedActivationGrain
+    {
+        private int _activationValue;
+
+        public override Task OnActivateAsync()
+        {
+            _activationValue = this.State.Value;
+            return Task.CompletedTask;
+        }
+
+        public Task<int> GetStateValue() => Task.FromResult(State.Value);
+
+        public Task<int> GetActivationValue() => Task.FromResult(_activationValue);
+    }
+
+    public sealed class StatefulNonSupportedActivationGrainState
+    {
+        public StatefulNonSupportedActivationGrainState(int activationValue)
+        {
+            Value = activationValue;
+        }
+
+        public int Value { get; set; }
+    }
+}

--- a/test/OrleansTestKit.Tests/Tests/ActivationGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ActivationGrainTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using TestGrains;
@@ -20,6 +21,21 @@ namespace Orleans.TestKit.Tests
 
             // Assert
             value.Should().Be(123);
+        }
+
+        /// <summary>
+        /// This test demonstrates what happens when you try activating a grain with a state that does not have a a parameterless constructor.
+        /// The exception should help the user to find out what the problem is.
+        /// </summary>
+        [Fact]
+        public async Task ShouldThrowNotSupportedException()
+        {
+            // Arrange
+
+
+            // Act and Assert
+            await Assert.ThrowsAsync<NotSupportedException>(
+                async () => await Silo.CreateGrainAsync<StatefulUnsupportedActivationGrain>(0));
         }
     }
 }


### PR DESCRIPTION
- Update Microsoft.Orleans.OrleansRuntime Version to 3.1.1
- Update Version of OrleansTestKit to 3.1.0
- Update Copyright to include 2020
- Work around removed new() constraint of grainstates