### PR TITLE
Revert RegistrationStrategy change and upgrade to Orleans 3.1.2

### DIFF
--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -15,7 +15,7 @@
     <PackageTags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET Test Testing</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/OrleansTestKit/TestGrainActivationContext.cs
+++ b/src/OrleansTestKit/TestGrainActivationContext.cs
@@ -7,8 +7,7 @@ using Orleans.Runtime;
 
 namespace Orleans.TestKit
 {
-    public sealed class TestGrainActivationContext :
-        IGrainActivationContext
+    public sealed class TestGrainActivationContext : IGrainActivationContext
     {
         public IServiceProvider ActivationServices { get; set; }
 
@@ -23,5 +22,8 @@ namespace Orleans.TestKit
         public IDictionary<object, object> Items => throw new NotImplementedException();
 
         public IGrainLifecycle ObservableLifecycle { get; set; }
+
+        [SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations")]
+        public IMultiClusterRegistrationStrategy RegistrationStrategy => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
The RegistrationStrategy was removed in error, and Orleans 3.1.2 is a re-release of Orleans 3.1.1 that fixes build/packaging issues. Fixes #88.