### PR TITLE
Add RecordExists members for v3.3.0

### DIFF
--- a/src/OrleansTestKit/Storage/TestStorage.cs
+++ b/src/OrleansTestKit/Storage/TestStorage.cs
@@ -1,10 +1,10 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Orleans.Core;
 
 namespace Orleans.TestKit.Storage
 {
-    internal sealed class TestStorage<TState> :
+    internal class TestStorage<TState> :
         IStorageStats,
         IStorage<TState>
     {
@@ -13,6 +13,8 @@ namespace Orleans.TestKit.Storage
         public TState State { get; set; }
 
         public string Etag => throw new System.NotImplementedException();
+
+        public virtual bool RecordExists => throw new NotImplementedException();
 
         public TestStorage()
         {

--- a/test/OrleansTestKit.Tests/Tests/StorageTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageTests.cs
@@ -193,6 +193,8 @@ namespace Orleans.TestKit.Tests
 
         public string Etag => throw new System.NotImplementedException();
 
+        public virtual bool RecordExists => throw new NotImplementedException();
+
         public CustomStorage()
         {
             Stats = new TestStorageStats() { Reads = -1 };


### PR DESCRIPTION
Fixes #95

Added members as `virtual` so they can match the interface without depending on the exact version.