### PR TITLE
Migrate to new .NET analyzers

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
+    "allowPrerelease": true,
+    "rollForward": "latestFeature",
     "version": "3.1.301"
   }
 }

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -15,10 +15,12 @@
     <PackageTags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET Test Testing</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>3.1.3</Version>
+    <Version>3.1.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <NoWarn>1591</NoWarn>
@@ -27,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
@@ -15,8 +16,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
Replaces `Microsoft.CodeAnalysis.FxCopAnalyzers` with `Microsoft.CodeAnalysis.NetAnalyzers` (see [docs](https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019)).