### PR TITLE
Added test for creating and mocking multiple grain probes

### DIFF
--- a/test/OrleansTestKit.Tests/Grains/IUnknownGrainResolver.cs
+++ b/test/OrleansTestKit.Tests/Grains/IUnknownGrainResolver.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+
+namespace TestGrains
+{
+    public interface IUnknownGrainResolver : IGrainWithStringKey
+    {
+        Task<List<string>> GetResolvedUnknownGrainIdsAsync();
+
+        Task CreateAndPingMultiple();
+    }
+}

--- a/test/OrleansTestKit.Tests/Grains/PingGrain.cs
+++ b/test/OrleansTestKit.Tests/Grains/PingGrain.cs
@@ -9,7 +9,6 @@ namespace TestGrains
     public class PingGrain : Grain, IPing
     {
 
-        public List<long> WhatsMyIdResults { get; } = new List<long>();
 
         public Task Ping()
         {
@@ -25,13 +24,5 @@ namespace TestGrains
             return pong.Pong();
         }
 
-        public async Task CreateAndPingMultiple()
-        {
-            var pongOne = GrainFactory.GetGrain<IPong>(1);
-            var pongTwo = GrainFactory.GetGrain<IPong>(2);
-
-            WhatsMyIdResults.Add(await pongOne.WhatsMyId());
-            WhatsMyIdResults.Add(await pongTwo.WhatsMyId());
-        }
     }
 }

--- a/test/OrleansTestKit.Tests/Grains/PingGrain.cs
+++ b/test/OrleansTestKit.Tests/Grains/PingGrain.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Orleans;
 using TestInterfaces;
 
@@ -6,6 +8,9 @@ namespace TestGrains
 {
     public class PingGrain : Grain, IPing
     {
+
+        public List<long> WhatsMyIdResults { get; } = new List<long>();
+
         public Task Ping()
         {
             var pong = GrainFactory.GetGrain<IPong>(22);
@@ -18,6 +23,15 @@ namespace TestGrains
             var pong = GrainFactory.GetGrain<IPongCompound>(44, keyExtension: "Test");
 
             return pong.Pong();
+        }
+
+        public async Task CreateAndPingMultiple()
+        {
+            var pongOne = GrainFactory.GetGrain<IPong>(1);
+            var pongTwo = GrainFactory.GetGrain<IPong>(2);
+
+            WhatsMyIdResults.Add(await pongOne.WhatsMyId());
+            WhatsMyIdResults.Add(await pongTwo.WhatsMyId());
         }
     }
 }

--- a/test/OrleansTestKit.Tests/Grains/UnknownGrainResolver.cs
+++ b/test/OrleansTestKit.Tests/Grains/UnknownGrainResolver.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans;
+using TestInterfaces;
+
+namespace TestGrains
+{
+    public class UnknownGrainResolver : Grain, IGrainWithStringKey
+    {
+        
+        public List<string> ResolvedUnknownGrainIds { get; } = new List<string>();
+        
+        public async Task CreateAndPingMultiple()
+        {
+            var unknownGrainOne = GrainFactory.GetGrain<IUnknownGrain>("unknownGrainOne");
+            var unknownGrainTwo = GrainFactory.GetGrain<IUnknownGrain>("unknownGrainTwo");
+
+            ResolvedUnknownGrainIds.Add(await unknownGrainOne.WhatsMyId());
+            ResolvedUnknownGrainIds.Add(await unknownGrainTwo.WhatsMyId());
+        }
+    }
+}

--- a/test/OrleansTestKit.Tests/Grains/UnknownGrainResolver.cs
+++ b/test/OrleansTestKit.Tests/Grains/UnknownGrainResolver.cs
@@ -5,18 +5,19 @@ using TestInterfaces;
 
 namespace TestGrains
 {
-    public class UnknownGrainResolver : Grain, IGrainWithStringKey
+    public class UnknownGrainResolver : Grain, IUnknownGrainResolver
     {
-        
-        public List<string> ResolvedUnknownGrainIds { get; } = new List<string>();
+        private List<string> _resolvedIds = new List<string>();
+
+        public Task<List<string>> GetResolvedUnknownGrainIdsAsync() => Task.FromResult(_resolvedIds); 
         
         public async Task CreateAndPingMultiple()
         {
             var unknownGrainOne = GrainFactory.GetGrain<IUnknownGrain>("unknownGrainOne");
             var unknownGrainTwo = GrainFactory.GetGrain<IUnknownGrain>("unknownGrainTwo");
 
-            ResolvedUnknownGrainIds.Add(await unknownGrainOne.WhatsMyId());
-            ResolvedUnknownGrainIds.Add(await unknownGrainTwo.WhatsMyId());
+            _resolvedIds.Add(await unknownGrainOne.WhatsMyId());
+            _resolvedIds.Add(await unknownGrainTwo.WhatsMyId());
         }
     }
 }

--- a/test/OrleansTestKit.Tests/Interfaces/IPong.cs
+++ b/test/OrleansTestKit.Tests/Interfaces/IPong.cs
@@ -5,7 +5,6 @@ namespace TestInterfaces
 {
     public interface IPong : IGrainWithIntegerKey
     {
-        Task<long> WhatsMyId();
         Task Pong();
     }
 }

--- a/test/OrleansTestKit.Tests/Interfaces/IPong.cs
+++ b/test/OrleansTestKit.Tests/Interfaces/IPong.cs
@@ -5,6 +5,7 @@ namespace TestInterfaces
 {
     public interface IPong : IGrainWithIntegerKey
     {
+        Task<long> WhatsMyId();
         Task Pong();
     }
 }

--- a/test/OrleansTestKit.Tests/Interfaces/IUnknownGrain.cs
+++ b/test/OrleansTestKit.Tests/Interfaces/IUnknownGrain.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+
+namespace TestInterfaces
+{
+    public interface IUnknownGrain : IGrainWithStringKey
+    {
+        //this grain's identity is not known when it is resolved
+        //for instance, if GrainA needs to create another NEW IUnknownGrain it would generate a new idea and ask the GrainFactory for a reference
+        //in this case a test of GrainA would not know the id in advance and would not be able to set up a probe using the id.
+        
+        Task<string> WhatsMyId();
+    }
+}

--- a/test/OrleansTestKit.Tests/Interfaces/IUnknownGrain.cs
+++ b/test/OrleansTestKit.Tests/Interfaces/IUnknownGrain.cs
@@ -6,7 +6,7 @@ namespace TestInterfaces
     public interface IUnknownGrain : IGrainWithStringKey
     {
         //this grain's identity is not known when it is resolved
-        //for instance, if GrainA needs to create another NEW IUnknownGrain it would generate a new idea and ask the GrainFactory for a reference
+        //for instance, if GrainA needs to create another NEW IUnknownGrain it would generate a new id and ask the GrainFactory for a reference 
         //in this case a test of GrainA would not know the id in advance and would not be able to set up a probe using the id.
         
         Task<string> WhatsMyId();

--- a/test/OrleansTestKit.Tests/Tests/GrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/GrainProbeTests.cs
@@ -167,8 +167,9 @@ namespace Orleans.TestKit.Tests
 
             await grain.CreateAndPingMultiple();
 
-            grain.ResolvedUnknownGrainIds[0].Should().Be("unknownGrainOne");
-            grain.ResolvedUnknownGrainIds[1].Should().Be("unknownGrainTwo");
+            var resolvedIds = await grain.GetResolvedUnknownGrainIdsAsync();
+            resolvedIds[0].Should().Be("unknownGrainOne");
+            resolvedIds[1].Should().Be("unknownGrainTwo");
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #101 

It turns out there is already a test for a simple probe factory case, so I added one for the more complicated case where multiple grains are created, and probes need to be set up for each of them to return a value based on the id they actually end up being created with by the grain under test.

PS I extended the existing Ping/Pong test classes rather than creating new ones - can redo if required. 