### PR TITLE
Add method for adding PersistentState for grains using PersistentStateFacets

### DIFF
--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.4.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/OrleansTestKit/Storage/StorageExtensions.cs
+++ b/src/OrleansTestKit/Storage/StorageExtensions.cs
@@ -61,33 +61,18 @@ namespace Orleans.TestKit
                 throw new ArgumentNullException(nameof(silo));
             }
 
-            silo.StorageManager.AddStorage(storage, stateName);
-            var stateMock = new PersistentStateFake<T>(storage)
-            {
-                State = state ?? new T()
-            };
-
-            var mockMapper = silo.StorageManager.stateAttributeFactoryMapperMock;
-
             if (string.IsNullOrWhiteSpace(stateName))
             {
-                mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(_ => stateMock);
-            }
-            else if (string.IsNullOrWhiteSpace(storageName))
-            {
-                mockMapper
-                    .Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.Is<PersistentStateAttribute>(attr => attr.StateName.Equals(stateName, StringComparison.OrdinalIgnoreCase))))
-                    .Returns(_ => stateMock);
-            }
-            else
-            {
-                mockMapper
-                    .Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.Is<PersistentStateAttribute>(attr =>
-                        attr.StateName.Equals(stateName, StringComparison.OrdinalIgnoreCase) && (attr.StorageName == null || attr.StorageName.Equals(storageName, StringComparison.OrdinalIgnoreCase)))))
-                    .Returns(_ => stateMock);
+                throw new ArgumentException("A state name must be provided", nameof(stateName));
             }
 
-            return stateMock;
+            if (storage is null)
+            {
+                throw new ArgumentNullException(nameof(storage));
+            }
+
+            silo.StorageManager.AddStorage(storage, stateName);
+            return silo.StorageManager.stateAttributeFactoryMapper.AddPersistentState(storage, stateName, storageName, state);
         }
     }
 

--- a/src/OrleansTestKit/Storage/StorageExtensions.cs
+++ b/src/OrleansTestKit/Storage/StorageExtensions.cs
@@ -1,5 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Reflection;
+using System.Threading.Tasks;
+using Moq;
+using Orleans.Core;
+using Orleans.Runtime;
 using Orleans.TestKit.Storage;
 
 namespace Orleans.TestKit
@@ -25,5 +30,90 @@ namespace Orleans.TestKit
 
             return silo.StorageManager.StorageStats;
         }
+
+        public static IPersistentState<T> AddPersistentState<T>(
+            this TestKitSilo silo,
+            string stateName = default,
+            string storageName = default,
+            T state = default)
+            where T : new()
+        {
+            if (silo == null)
+            {
+                throw new ArgumentNullException(nameof(silo));
+            }
+
+            var storage = silo.StorageManager.GetStorage<T>(stateName);
+
+            return AddPersistentState(silo, storage, stateName, storageName, state);
+        }
+
+        public static IPersistentState<T> AddPersistentState<T>(
+            this TestKitSilo silo,
+            IStorage<T> storage,
+            string stateName = default,
+            string storageName = default,
+            T state = default)
+            where T : new()
+        {
+            if (silo == null)
+            {
+                throw new ArgumentNullException(nameof(silo));
+            }
+
+            silo.StorageManager.AddStorage(storage, stateName);
+            var stateMock = new PersistentStateFake<T>(storage)
+            {
+                State = state ?? new T()
+            };
+
+            var mockMapper = silo.StorageManager.stateAttributeFactoryMapperMock;
+
+            if (string.IsNullOrWhiteSpace(stateName))
+            {
+                mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(_ => stateMock);
+            }
+            else if (string.IsNullOrWhiteSpace(storageName))
+            {
+                mockMapper
+                    .Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.Is<PersistentStateAttribute>(attr => attr.StateName.Equals(stateName, StringComparison.OrdinalIgnoreCase))))
+                    .Returns(_ => stateMock);
+            }
+            else
+            {
+                mockMapper
+                    .Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.Is<PersistentStateAttribute>(attr =>
+                        attr.StateName.Equals(stateName, StringComparison.OrdinalIgnoreCase) && (attr.StorageName == null || attr.StorageName.Equals(storageName, StringComparison.OrdinalIgnoreCase)))))
+                    .Returns(_ => stateMock);
+            }
+
+            return stateMock;
+        }
+    }
+
+    internal class PersistentStateFake<TState> : IPersistentState<TState>
+    {
+        private readonly IStorage<TState> _storage;
+
+        public PersistentStateFake(IStorage<TState> storage)
+        {
+            _storage = storage;
+        }
+
+        public TState State
+        {
+            get => _storage.State;
+            set => _storage.State = value;
+        }
+
+        public string Etag => _storage.Etag;
+
+        public bool RecordExists => _storage.RecordExists;
+
+        public Task ClearStateAsync() => _storage.ClearStateAsync();
+
+        public Task ReadStateAsync() => _storage.ReadStateAsync();
+
+        public Task WriteStateAsync() => _storage.WriteStateAsync();
     }
 }

--- a/src/OrleansTestKit/Storage/StorageExtensions.cs
+++ b/src/OrleansTestKit/Storage/StorageExtensions.cs
@@ -14,7 +14,6 @@ namespace Orleans.TestKit
     {
         public static TState State<TGrain, TState>(this TestKitSilo silo)
             where TGrain : Grain<TState>
-            where TState : class, new()
         {
             if (silo == null)
             {
@@ -39,7 +38,6 @@ namespace Orleans.TestKit
             this TestKitSilo silo,
             T state = default)
             where TGrain : Grain<T>
-            where T : new()
         {
             if (silo == null)
             {
@@ -47,7 +45,7 @@ namespace Orleans.TestKit
             }
 
             var storage = silo.StorageManager.GetGrainStorage<TGrain, T>();
-            storage.State = state ?? new T();
+            storage.State = state ?? Activator.CreateInstance<T>();
             return storage;
         }
 
@@ -68,12 +66,11 @@ namespace Orleans.TestKit
             string stateName,
             string storageName = default,
             T state = default)
-            where T : new()
         {
             return silo.AddPersistentStateStorage(
                 stateName,
                 storageName,
-                new TestStorage<T>(state ?? new T()));
+                new TestStorage<T>(state ?? Activator.CreateInstance<T>()));
         }
 
         /// <summary>
@@ -93,9 +90,8 @@ namespace Orleans.TestKit
             string stateName,
             string storageName = default,
             IStorage<T> storage = default)
-            where T : new()
         {
-            var normalizedStorage = storage ?? new TestStorage<T>(new T());
+            var normalizedStorage = storage ?? new TestStorage<T>(Activator.CreateInstance<T>());
             var normalizedStorageName = storageName ?? "Default";
 
             if (silo == null)

--- a/src/OrleansTestKit/Storage/StorageManager.cs
+++ b/src/OrleansTestKit/Storage/StorageManager.cs
@@ -13,11 +13,13 @@ namespace Orleans.TestKit.Storage
 
         private readonly Dictionary<string, object> _storages = new Dictionary<string, object>();
 
-        public StorageManager(TestKitOptions options) =>
+        public StorageManager(TestKitOptions options)
+        {
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            stateAttributeFactoryMapper = new TestPersistentStateAttributeToFactoryMapper(this);
+        }
 
-        internal readonly Mock<IAttributeToFactoryMapper<PersistentStateAttribute>> stateAttributeFactoryMapperMock =
-            new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        internal readonly TestPersistentStateAttributeToFactoryMapper stateAttributeFactoryMapper;
 
         public IStorage<TState> GetStorage<TState>() => GetStorage<TState>("Default");
 

--- a/src/OrleansTestKit/Storage/TestPersistentStateAttributeToFactoryMapper.cs
+++ b/src/OrleansTestKit/Storage/TestPersistentStateAttributeToFactoryMapper.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Orleans.Core;
+using Orleans.Runtime;
+
+namespace Orleans.TestKit.Storage
+{
+    public sealed class TestPersistentStateAttributeToFactoryMapper : IAttributeToFactoryMapper<PersistentStateAttribute>
+    {
+        private readonly StorageManager storageManager;
+        private readonly Dictionary<Type, Dictionary<(string StateName, string StorageName), object>>
+            registeredStorage = new();
+        private readonly MethodInfo AddEmptyStateMethod = typeof(TestPersistentStateAttributeToFactoryMapper)
+            .GetMethod(nameof(TestPersistentStateAttributeToFactoryMapper.AddEmptyState), BindingFlags.Instance | BindingFlags.NonPublic);
+
+        public TestPersistentStateAttributeToFactoryMapper(StorageManager storageManager)
+        {
+            this.storageManager = storageManager;
+        }
+
+        public IPersistentState<T> AddPersistentState<T>(
+            IStorage<T> storage,
+            string stateName,
+            string storageName = null,
+            T state = default) where T : new()
+        {
+            var dict = registeredStorage.TryGetValue(typeof(T), out var typeStateRegistry)
+                ? typeStateRegistry
+                : registeredStorage[typeof(T)] = new Dictionary<(string StateName, string StorageName), object>(1);
+
+            var fake = new PersistentStateFake<T>(storage)
+            {
+                State = state ?? new T()
+            };
+            dict[(stateName, storageName)] = fake;
+
+            return fake;
+        }
+
+        public Factory<IGrainActivationContext, object> GetFactory(ParameterInfo parameter, PersistentStateAttribute metadata)
+        {
+            if (parameter is null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            if (metadata is null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
+            if (parameter.ParameterType.IsGenericType &&
+                parameter.ParameterType.GetGenericTypeDefinition() != typeof(IPersistentState<>))
+            {
+                throw new InvalidOperationException($"No persistent state for the parameter '{parameter.Name}'");
+            }
+
+            var parameterType = parameter.ParameterType.GenericTypeArguments[0];
+
+            if (registeredStorage.TryGetValue(parameterType, out var typeStateRegistry))
+            {
+                // If a storage name is not provided then find it by the state name
+                if (metadata.StorageName is null)
+                {
+                    foreach (var kvp in typeStateRegistry)
+                    {
+                        if (kvp.Key.StateName == metadata.StateName)
+                        {
+                            return _ => kvp.Value;
+                        }
+                    }
+                }
+                // If we must have the state and the storage name so lookup by both
+                else if (typeStateRegistry.TryGetValue((metadata.StateName, metadata.StorageName), out var persistentState))
+                {
+                    return _ => persistentState;
+                }
+            }
+
+            var state = AddEmptyStateMethod.MakeGenericMethod(parameterType).Invoke(
+                this,
+                new[] { metadata.StateName, metadata.StorageName });
+
+            return _ => state;
+        }
+
+        private IPersistentState<TState> AddEmptyState<TState>(string stateName, string storageName)
+            where TState : new()
+        {
+            var storage = storageManager.GetStorage<TState>(stateName);
+            return AddPersistentState(storage, stateName, storageName);
+        }
+    }
+}

--- a/src/OrleansTestKit/Storage/TestPersistentStateAttributeToFactoryMapper.cs
+++ b/src/OrleansTestKit/Storage/TestPersistentStateAttributeToFactoryMapper.cs
@@ -86,7 +86,6 @@ namespace Orleans.TestKit.Storage
         }
 
         private IPersistentState<TState> AddEmptyState<TState>(string stateName, string storageName)
-            where TState : new()
         {
             var storage = storageManager.GetStorage<TState>(stateName);
             return AddPersistentState(storage, stateName, storageName);

--- a/src/OrleansTestKit/Storage/TestStorage.cs
+++ b/src/OrleansTestKit/Storage/TestStorage.cs
@@ -8,10 +8,14 @@ namespace Orleans.TestKit.Storage
         IStorageStats,
         IStorage<TState>
     {
-        public TestStorage()
+        public TestStorage() : this(CreateState())
+        {
+        }
+
+        public TestStorage(TState state)
         {
             Stats = new TestStorageStats() { Reads = -1 };
-            InitializeState();
+            State = state;
         }
 
         public string Etag => throw new System.NotImplementedException();
@@ -24,7 +28,7 @@ namespace Orleans.TestKit.Storage
 
         public Task ClearStateAsync()
         {
-            InitializeState();
+            State = CreateState();
             Stats.Clears++;
             RecordExists = false;
             return Task.CompletedTask;
@@ -43,7 +47,7 @@ namespace Orleans.TestKit.Storage
             return Task.CompletedTask;
         }
 
-        private void InitializeState()
+        private static TState CreateState()
         {
             if (!typeof(TState).IsValueType && typeof(TState).GetConstructor(Type.EmptyTypes) == null)
             {
@@ -51,7 +55,7 @@ namespace Orleans.TestKit.Storage
                     $"No parameterless constructor defined for {typeof(TState).Name}. This is currently not supported");
             }
 
-            State = Activator.CreateInstance<TState>();
+            return Activator.CreateInstance<TState>();
         }
     }
 }

--- a/src/OrleansTestKit/TestGrainRuntime.cs
+++ b/src/OrleansTestKit/TestGrainRuntime.cs
@@ -58,6 +58,6 @@ namespace Orleans.TestKit
         }
 
         public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) =>
-            _storageManager.GetStorage<TGrainState>();
+            _storageManager.GetStorage<TGrainState>(grain.GetType().FullName);
     }
 }

--- a/src/OrleansTestKit/TestGrainRuntime.cs
+++ b/src/OrleansTestKit/TestGrainRuntime.cs
@@ -57,7 +57,7 @@ namespace Orleans.TestKit
             Mock.Object.DelayDeactivation(grain, timeSpan);
         }
 
-        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain) =>
-            _storageManager.GetStorage<TGrainState>(grain.GetType().FullName);
+        public IStorage<TGrainState> GetStorage<TGrainState>(Grain grain)
+            => _storageManager.GetStorage<TGrainState>(grain.GetType().FullName);
     }
 }

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -111,6 +111,9 @@ namespace Orleans.TestKit
                 throw new Exception("A grain has already been created in this silo. Only 1 grain per test silo should ever be created. Add grain probes for supporting grains.");
             }
 
+            // Add state attribute mapping for storage facets
+            this.AddService(StorageManager.stateAttributeFactoryMapperMock.Object);
+
             _isGrainCreated = true;
             Grain grain;
             var grainContext = new TestGrainActivationContext

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -112,7 +112,7 @@ namespace Orleans.TestKit
             }
 
             // Add state attribute mapping for storage facets
-            this.AddService(StorageManager.stateAttributeFactoryMapperMock.Object);
+            this.AddService<IAttributeToFactoryMapper<PersistentStateAttribute>>(StorageManager.stateAttributeFactoryMapper);
 
             _isGrainCreated = true;
             Grain grain;

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -112,7 +112,7 @@ namespace Orleans.TestKit
             }
 
             // Add state attribute mapping for storage facets
-            this.AddService<IAttributeToFactoryMapper<PersistentStateAttribute>>(StorageManager.stateAttributeFactoryMapper);
+            this.AddService<IAttributeToFactoryMapper<PersistentStateAttribute>>(StorageManager.StateAttributeFactoryMapper);
 
             _isGrainCreated = true;
             Grain grain;

--- a/test/OrleansTestKit.Tests/Grains/ColorRankingGrain.cs
+++ b/test/OrleansTestKit.Tests/Grains/ColorRankingGrain.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using TestInterfaces;
+
+namespace TestGrains
+{
+    public class ColorRankingGrain : Grain<ColorGrainState>, IColorRankingGrain
+    {
+        /// <summary>The persisted state.</summary>
+        private readonly IPersistentState<ColorGrainState> state;
+
+        public ColorRankingGrain(
+            [PersistentState("Default")]
+            IPersistentState<ColorGrainState> state)
+        {
+            this.state = state;
+        }
+
+        public Task<Color> GetFavouriteColor() => Task.FromResult(state.State.Color);
+
+        public Task<Color> GetLeastFavouriteColor() => Task.FromResult(State.Color);
+
+        /// <summary>Asynchronously sets the favourite color.</summary>
+        /// <param name="color">The new color.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///     If <paramref name="color"/> is <see cref="Color.Unknown"/> or an invalid value.
+        /// </exception>
+        public async Task SetFavouriteColor(Color color)
+        {
+            SetColor(color, state.State);
+            await state.WriteStateAsync();
+        }
+
+        /// <summary>Asynchronously sets the least favourite color.</summary>
+        /// <param name="color">The new color.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///     If <paramref name="color"/> is <see cref="Color.Unknown"/> or an invalid value.
+        /// </exception>
+        public async Task SetLeastFavouriteColor(Color color)
+        {
+            SetColor(color, State);
+            await WriteStateAsync();
+        }
+
+        private void SetColor(Color color, ColorGrainState state)
+        {
+            if (!Enum.IsDefined(typeof(Color), color))
+            {
+                throw new ArgumentException("The color is invalid.", nameof(color));
+            }
+
+            if (color == Color.Unknown)
+            {
+                throw new ArgumentException("The color must not be \"unknown\".", nameof(color));
+            }
+
+            if (this.state.State.Initialized)
+            {
+                if (color == state.Color)
+                {
+                    return;
+                }
+            }
+            else
+            {
+                state.Id = this.GetPrimaryKey();
+            }
+
+            state.Color = color;
+        }
+    }
+}

--- a/test/OrleansTestKit.Tests/Interfaces/IColorRankingGrain.cs
+++ b/test/OrleansTestKit.Tests/Interfaces/IColorRankingGrain.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Orleans;
+
+namespace TestInterfaces
+{
+    public interface IColorRankingGrain : IGrainWithGuidKey
+    {
+        Task<Color> GetFavouriteColor();
+        Task<Color> GetLeastFavouriteColor();
+        Task SetFavouriteColor(Color color);
+        Task SetLeastFavouriteColor(Color color);
+    }
+}

--- a/test/OrleansTestKit.Tests/Tests/PersistantStreamNotWithinGrainStateTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/PersistantStreamNotWithinGrainStateTests.cs
@@ -14,22 +14,14 @@ namespace Orleans.TestKit.Tests
     {
 
         private readonly PersistentListenerStateWithoutHandle _stateWithoutHandle;
-        private readonly Mock<IPersistentState<PersistentListenerStateWithoutHandle>> _persistentState;
         private readonly TestStream<ChatMessage> _stream;
 
         public PersistantStreamNotWithinGrainStateTests()
         {
             _stateWithoutHandle = new PersistentListenerStateWithoutHandle();
 
-            _persistentState = new Mock<IPersistentState<PersistentListenerStateWithoutHandle>>();
-            _persistentState.SetupGet(o => o.State).Returns(_stateWithoutHandle);
-
-            var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-            mockMapper.Setup(o =>
-                    o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>()))
-                .Returns(context => _persistentState.Object);
-
-            Silo.AddService(mockMapper.Object);
+            Silo.AddPersistentState(
+                "listenerStateWithoutHandler", state: _stateWithoutHandle);
 
             _stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null, "Default");
         }

--- a/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
@@ -20,7 +20,7 @@ namespace Orleans.TestKit.Tests
         public async Task GetColor_WithDefaultState_ReturnsUnknown()
         {
             // Arrange
-            Silo.AddPersistentState<ColorGrainState>();
+            Silo.AddPersistentState<ColorGrainState>("State");
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -41,7 +41,7 @@ namespace Orleans.TestKit.Tests
                 Id = GrainId,
             };
 
-            Silo.AddPersistentState(state: state);
+            Silo.AddPersistentState(stateName: "State", state: state);
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -57,7 +57,7 @@ namespace Orleans.TestKit.Tests
         {
             // Arrange
             var state = new ColorGrainState();
-            Silo.AddPersistentState(state: state);
+            Silo.AddPersistentState(stateName: "State", state: state);
 
             // Act
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
@@ -72,7 +72,7 @@ namespace Orleans.TestKit.Tests
         {
             // Arrange
             var state = new ColorGrainState();
-            Silo.AddPersistentState(state: state);
+            Silo.AddPersistentState(stateName: "State", state: state);
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -86,7 +86,7 @@ namespace Orleans.TestKit.Tests
             // Note that the following assert ties this test to the _implementation_ details. Generally, one should try
             // to avoid tying the test to the implementation details. It can lead to more brittle tests. However, one may
             // choose to accept this as a trade-off when the implementation detail represents an important behavior.
-            var storageStats = Silo.StorageManager.GetStorageStats();
+            var storageStats = Silo.StorageManager.GetStorageStats(stateName: "State");
             storageStats.Clears.Should().Be(0);
         }
 
@@ -99,7 +99,7 @@ namespace Orleans.TestKit.Tests
                 Color = Color.Red,
                 Id = GrainId,
             };
-            Silo.AddPersistentState(state: state);
+            Silo.AddPersistentState(stateName: "State", state: state);
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -107,7 +107,7 @@ namespace Orleans.TestKit.Tests
             await grain.ResetColor();
 
             // Assert
-            var storageStats = Silo.StorageManager.GetStorageStats();
+            var storageStats = Silo.StorageManager.GetStorageStats(stateName: "State");
             storageStats.Clears.Should().Be(1);
         }
 
@@ -116,7 +116,7 @@ namespace Orleans.TestKit.Tests
         {
             // Arrange
             var state = new ColorGrainState();
-            Silo.AddPersistentState(state: state);
+            Silo.AddPersistentState(stateName: "State", state: state);
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -134,7 +134,7 @@ namespace Orleans.TestKit.Tests
         public async Task SetColor_WithInvalidColor_ThrowsArgumentException(Color color)
         {
             // Arrange
-            Silo.AddPersistentState<ColorGrainState>();
+            Silo.AddPersistentState<ColorGrainState>(stateName: "State");
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
             Action action = () => grain.SetColor(color);
@@ -152,7 +152,7 @@ namespace Orleans.TestKit.Tests
             mock.SetupAllProperties();
             mock.Setup(o => o.WriteStateAsync()).Throws<InconsistentStateException>();
 
-            Silo.AddPersistentState(storage: mock.Object);
+            Silo.AddPersistentState(stateName: "State", storage: mock.Object);
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
             Action action = () => grain.SetColor(Color.Green);
@@ -170,7 +170,7 @@ namespace Orleans.TestKit.Tests
                 Color = Color.Red,
                 Id = GrainId,
             };
-            Silo.AddPersistentState(state: state);
+            Silo.AddPersistentState(stateName: "State", state: state);
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 

--- a/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
@@ -181,5 +181,93 @@ namespace Orleans.TestKit.Tests
             state.Color.Should().Be(Color.Blue);
             state.Id.Should().Be(GrainId);
         }
+
+        [Fact]
+        public async Task GetColor_WithGrainState_ReturnsColor()
+        {
+            // Arrange
+            var state = new ColorGrainState
+            {
+                Color = Color.Red,
+                Id = GrainId,
+            };
+
+            Silo.AddGrainState<ColorRankingGrain, ColorGrainState>(state: state);
+
+            var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+            // Act
+            var color = await grain.GetLeastFavouriteColor();
+            color.Should().Be(Color.Red);
+        }
+
+        [Fact]
+        public async Task SetLeastFavouriteColor_WithDefaultGrainState_SetsState()
+        {
+            var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+            // Act
+            await grain.SetLeastFavouriteColor(Color.Blue);
+
+            var storage = Silo.StorageManager.GetGrainStorage<ColorRankingGrain, ColorGrainState>();
+            var state = storage.State;
+
+            state.Color.Should().Be(Color.Blue);
+            state.Id.Should().Be(GrainId);
+        }
+
+        [Fact]
+        public async Task GetLeastFavouriteColor_WithGrainState_ReturnsColor()
+        {
+            // Arrange
+            var state = new ColorGrainState
+            {
+                Color = Color.Red,
+                Id = GrainId,
+            };
+
+            Silo.AddGrainState<ColorRankingGrain, ColorGrainState>(state: state);
+
+            var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+            // Act
+            var color = await grain.GetLeastFavouriteColor();
+            color.Should().Be(Color.Red);
+        }
+
+        [Fact]
+        public async Task SetFavouriteColor_WithState_SetsState()
+        {
+            var persistentState = Silo.AddPersistentState("Default", state: new ColorGrainState
+            {
+                Id = GrainId,
+                Color = Color.Red
+            });
+
+            var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+            // Act
+            await grain.SetFavouriteColor(Color.Blue);
+
+            var state = persistentState.State;
+            state.Color.Should().Be(Color.Blue);
+            state.Id.Should().Be(GrainId);
+        }
+
+        [Fact]
+        public async Task GetFavouriteColor_WithState_ReturnsColor()
+        {
+            Silo.AddPersistentState("Default", state: new ColorGrainState
+            {
+                Id = GrainId,
+                Color = Color.Blue
+            });
+
+            var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+            // Act
+            var color = await grain.GetFavouriteColor();
+            color.Should().Be(Color.Blue);
+        }
     }
 }

--- a/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
@@ -148,11 +148,13 @@ namespace Orleans.TestKit.Tests
         public async Task SetColor_WithMutatedState_ThrowsInconsistentStateException()
         {
             // Arrange
-            var mock = new Mock<IStorage<ColorGrainState>>();
-            mock.SetupAllProperties();
-            mock.Setup(o => o.WriteStateAsync()).Throws<InconsistentStateException>();
+            var state = new ColorGrainState();
 
-            Silo.AddPersistentState(stateName: "State", storage: mock.Object);
+            var mockState = new Mock<IStorage<ColorGrainState>>();
+            mockState.SetupGet(o => o.State).Returns(state);
+            mockState.Setup(o => o.WriteStateAsync()).Throws<InconsistentStateException>();
+
+            Silo.AddPersistentStateStorage(stateName: "State", storage: mockState.Object);
 
             var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
             Action action = () => grain.SetColor(Color.Green);

--- a/test/OrleansTestKit.Tests/Tests/StorageTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageTests.cs
@@ -83,10 +83,10 @@ namespace Orleans.TestKit.Tests
             var greetings = (await grain.GetGreetings()).ToList();
 
             // Assert
-            var state = this.Silo.State<GreetingArchiveGrainState>();
+            var state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
             state.Greetings.Should().Equal(greeting1, greeting2);
             greetings.Should().Equal(greeting1, greeting2);
-            Assert.True(this.Silo.StorageManager.GetStorage<GreetingArchiveGrainState>().RecordExists);
+            Assert.True(this.Silo.StorageManager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>().RecordExists);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Orleans.TestKit.Tests
             stats.Writes.Should().Be(2);
 
             greetings.Should().Equal(greeting1, greeting2);
-            Assert.True(this.Silo.StorageManager.GetStorage<GreetingArchiveGrainState>().RecordExists);
+            Assert.True(this.Silo.StorageManager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>().RecordExists);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace Orleans.TestKit.Tests
             const long id = 2000;
             const string greeting = "Hola";
 
-            var state = this.Silo.State<GreetingArchiveGrainState>();
+            var state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
             state.Greetings.Add(greeting);
 
             var grain = await this.Silo.CreateGrainAsync<GreetingArchiveGrain>(id);
@@ -187,7 +187,7 @@ namespace Orleans.TestKit.Tests
             const long id = 5000;
             const string greeting = "Olá";
 
-            var state = this.Silo.State<GreetingArchiveGrainState>();
+            var state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
             state.Greetings.Add(greeting);
 
             var grain = await this.Silo.CreateGrainAsync<GreetingArchiveGrain>(id);
@@ -198,11 +198,11 @@ namespace Orleans.TestKit.Tests
             var greetings = (await grain.GetGreetings()).ToList();
 
             // Assert
-            state = this.Silo.State<GreetingArchiveGrainState>();
+            state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
             state.Greetings.Should().BeEmpty();
 
             greetings.Should().BeEmpty();
-            Assert.False(this.Silo.StorageManager.GetStorage<GreetingArchiveGrainState>().RecordExists);
+            Assert.False(this.Silo.StorageManager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>().RecordExists);
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace Orleans.TestKit.Tests
             const long id = 6000;
             const string greeting = "Hallo";
 
-            var state = this.Silo.State<GreetingArchiveGrainState>();
+            var state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
             state.Greetings.Add(greeting);
 
             var grain = await this.Silo.CreateGrainAsync<GreetingArchiveGrain>(id);
@@ -233,7 +233,7 @@ namespace Orleans.TestKit.Tests
             stats.Writes.Should().Be(0);
 
             greetings.Should().BeEmpty();
-            Assert.False(this.Silo.StorageManager.GetStorage<GreetingArchiveGrainState>().RecordExists);
+            Assert.False(this.Silo.StorageManager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>().RecordExists);
         }
 
         /// <summary>This test demonstrates how to use the RecordExists flag</summary>
@@ -241,7 +241,7 @@ namespace Orleans.TestKit.Tests
         public async Task RecordExistsFlagTest()
         {
             var manager = new StorageManager(new TestKitOptions());
-            var state = manager.GetStorage<GreetingArchiveGrainState>();
+            var state = manager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>();
 
             // be default, RecordExists is false
             Assert.False(state.RecordExists);

--- a/test/OrleansTestKit.Tests/Tests/StorageTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageTests.cs
@@ -110,7 +110,7 @@ namespace Orleans.TestKit.Tests
             var greetings = (await grain.GetGreetings()).ToList();
 
             // Assert
-            var stats = this.Silo.StorageStats();
+            var stats = this.Silo.StorageStats<GreetingArchiveGrain, GreetingArchiveGrainState>();
             stats.Clears.Should().Be(0);
             stats.Reads.Should().Be(0);
             stats.Writes.Should().Be(2);
@@ -227,7 +227,7 @@ namespace Orleans.TestKit.Tests
             var greetings = (await grain.GetGreetings()).ToList();
 
             // Assert
-            var stats = this.Silo.StorageStats();
+            var stats = this.Silo.StorageStats<GreetingArchiveGrain, GreetingArchiveGrainState>();
             stats.Clears.Should().Be(1);
             stats.Reads.Should().Be(0);
             stats.Writes.Should().Be(0);

--- a/test/OrleansTestKit.Tests/Tests/TimerTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/TimerTests.cs
@@ -20,7 +20,7 @@ namespace Orleans.TestKit.Tests
             await Silo.FireAllTimersAsync();
 
             // Assert
-            var state = Silo.State<HelloTimersState>();
+            var state = Silo.State<HelloTimers, HelloTimersState>();
             state.Timer0Fired.Should().BeTrue();
             state.Timer1Fired.Should().BeTrue();
         }
@@ -37,7 +37,7 @@ namespace Orleans.TestKit.Tests
             await Silo.FireTimerAsync(0);
 
             // Assert
-            var state = Silo.State<HelloTimersState>();
+            var state = Silo.State<HelloTimers, HelloTimersState>();
             state.Timer0Fired.Should().BeTrue();
             state.Timer1Fired.Should().BeFalse();
         }
@@ -52,7 +52,7 @@ namespace Orleans.TestKit.Tests
             await Silo.FireTimerAsync(1);
 
             // Assert
-            var state = Silo.State<HelloTimersState>();
+            var state = Silo.State<HelloTimers, HelloTimersState>();
             state.Timer0Fired.Should().BeFalse();
             state.Timer1Fired.Should().BeTrue();
         }


### PR DESCRIPTION
This is based on @enewnham's helper method in the linked issue. I've extended it to allow you to add multiple persistent states on the grain identified by StateName and StorageName.

I had to change StorageManager to allow multiple storages to be registered. I didn't change the existing interface and instead made them default the state name to `Default`.

closes #55