### PR TITLE
Adding ability to keep track of number of timers

### DIFF
--- a/src/OrleansTestKit/Timers/TestTimer.cs
+++ b/src/OrleansTestKit/Timers/TestTimer.cs
@@ -7,11 +7,12 @@ namespace Orleans.TestKit.Timers
         IDisposable
     {
         private Func<object, Task> _asyncCallback;
-
+        private bool _isDisposed;
         private object _state;
 
         public TestTimer(Func<object, Task> asyncCallback, object state)
         {
+            _isDisposed = false;
             _asyncCallback = asyncCallback;
             _state = state;
         }
@@ -25,11 +26,13 @@ namespace Orleans.TestKit.Timers
 
             return _asyncCallback(_state);
         }
+        public bool IsDisposed => _isDisposed;
 
         public void Dispose()
         {
             _asyncCallback = null;
             _state = null;
+            _isDisposed = true;
         }
     }
 }

--- a/src/OrleansTestKit/Timers/TestTimerRegistry.cs
+++ b/src/OrleansTestKit/Timers/TestTimerRegistry.cs
@@ -36,5 +36,7 @@ namespace Orleans.TestKit.Timers
                 await testTimer.FireAsync().ConfigureAwait(false);
             }
         }
+
+        public int NumberOfTimers => _timers.Count;
     }
 }

--- a/src/OrleansTestKit/Timers/TestTimerRegistry.cs
+++ b/src/OrleansTestKit/Timers/TestTimerRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using Orleans.Timers;
@@ -37,6 +38,6 @@ namespace Orleans.TestKit.Timers
             }
         }
 
-        public int NumberOfTimers => _timers.Count;
+        public int NumberOfActiveTimers => _timers.Count(x => !x.IsDisposed);
     }
 }

--- a/test/OrleansTestKit.Tests/Grains/HelloTimers.cs
+++ b/test/OrleansTestKit.Tests/Grains/HelloTimers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Orleans;
 
@@ -9,6 +9,7 @@ namespace TestGrains
         private IDisposable _timer0;
         private IDisposable _timer1;
         private IDisposable _timer2;
+        private IDisposable _secretTimer;
 
         public override Task OnActivateAsync()
         {
@@ -17,6 +18,12 @@ namespace TestGrains
             _timer2 = RegisterTimer(_ => OnTimer2(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
 
             return base.OnActivateAsync();
+        }
+
+        public Task RegisterSecretTimer()
+        {
+            _secretTimer = RegisterTimer(_ => OnSecretTimer(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            return Task.CompletedTask;
         }
 
         public override Task OnDeactivateAsync()
@@ -43,6 +50,13 @@ namespace TestGrains
         {
             _timer2.Dispose();
             _timer2 = RegisterTimer(_ => OnTimer2(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            return Task.CompletedTask;
+        }
+
+        private Task OnSecretTimer()
+        {
+            _secretTimer?.Dispose();
+            _secretTimer = RegisterTimer(_ => OnSecretTimer(), null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
             return Task.CompletedTask;
         }
     }

--- a/test/OrleansTestKit.Tests/Tests/TimerTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/TimerTests.cs
@@ -55,5 +55,19 @@ namespace Orleans.TestKit.Tests
             state.Timer0Fired.Should().BeFalse();
             state.Timer1Fired.Should().BeTrue();
         }
+
+        [Fact]
+        public async Task ShouldRegisterSecretTimerAsync()
+        {
+            //Arrange
+            var grain = await Silo.CreateGrainAsync<HelloTimers>(0);
+            var initialActiveTimers = Silo.TimerRegistry.NumberOfTimers;
+
+            //Act
+            await grain.RegisterSecretTimer();
+
+            //Assert
+            Assert.Equal(initialActiveTimers + 1, Silo.TimerRegistry.NumberOfTimers);
+        }
     }
 }


### PR DESCRIPTION
Added the ability to track the number of active timers on a grain. Useful to see if a timer was set but without wanting to check if the callback had been called.