### PR TITLE
Update dependencies and bump NuGet package version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "codecov.tool": {
-      "version": "1.10.0",
+      "version": "1.13.0",
       "commands": [
         "codecov"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -92,8 +92,10 @@ csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
 [*.cs]
+dotnet_diagnostic.CA1014.severity = none
 dotnet_diagnostic.CA1030.severity = none
 dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA2201.severity = suggestion
 
 ##### Documents #####
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "ms-dotnettools.csharp"
+  ],
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,21 @@
 {
+  "dotnet-test-explorer.runInParallel": true,
+  "dotnet-test-explorer.testProjectPath": "/test/*.Tests",
   "editor.formatOnSave": true,
   "editor.minimap.maxColumn": 120,
   "editor.minimap.showSlider": "always",
   "editor.renderWhitespace": "all",
-  "editor.rulers": [120],
+  "editor.rulers": [
+    120
+  ],
   "files.autoSave": "afterDelay",
   "files.autoSaveDelay": 30000,
+  "files.exclude": {
+    "**/bin": true,
+    "**/obj": true
+  },
   "omnisharp.defaultLaunchSolution": "OrleansTestKit.sln",
+  "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true,
   "omnisharp.useEditorFormattingSettings": false
 }

--- a/OrleansTestKit.code-workspace
+++ b/OrleansTestKit.code-workspace
@@ -6,15 +6,23 @@
     }
   ],
   "settings": {
-    "dotnet-test-explorer.testProjectPath": "./test/OrleansTestKit.Tests",
+    "dotnet-test-explorer.runInParallel": true,
+    "dotnet-test-explorer.testProjectPath": "/test/*.Tests",
     "editor.formatOnSave": true,
     "editor.minimap.maxColumn": 120,
     "editor.minimap.showSlider": "always",
     "editor.renderWhitespace": "all",
-    "editor.rulers": [120],
+    "editor.rulers": [
+      120
+    ],
     "files.autoSave": "afterDelay",
     "files.autoSaveDelay": 30000,
+    "files.exclude": {
+      "**/bin": true,
+      "**/obj": true
+    },
     "omnisharp.defaultLaunchSolution": "OrleansTestKit.sln",
+    "omnisharp.enableEditorConfigSupport": true,
     "omnisharp.enableRoslynAnalyzers": true,
     "omnisharp.useEditorFormattingSettings": false
   }

--- a/OrleansTestKit.sln
+++ b/OrleansTestKit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30503.244
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{54C04CF7-7044-46E0-BC24-2A992F028557}"
 EndProject

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "allowPrerelease": true,
+    "allowPrerelease": false,
     "rollForward": "latestFeature",
-    "version": "3.1.301"
+    "version": "5.0.400"
   }
 }

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <NoWarn>1591</NoWarn>
@@ -29,16 +30,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.1.7" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET Test Testing</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>3.1.7</Version>
+    <Version>3.1.8</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OrleansTestKit/Storage/StorageExtensions.cs
+++ b/src/OrleansTestKit/Storage/StorageExtensions.cs
@@ -23,7 +23,7 @@ namespace Orleans.TestKit
                 throw new ArgumentNullException(nameof(silo));
             }
 
-            return silo.StorageManager.GetStorageStats();
+            return silo.StorageManager.StorageStats;
         }
     }
 }

--- a/src/OrleansTestKit/Storage/StorageManager.cs
+++ b/src/OrleansTestKit/Storage/StorageManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Orleans.Core;
 
 namespace Orleans.TestKit.Storage
@@ -22,11 +23,19 @@ namespace Orleans.TestKit.Storage
             return _storage as IStorage<TState>;
         }
 
-        public TestStorageStats GetStorageStats()
+        public TestStorageStats StorageStats
         {
-            //There should only be one state in here since there is only 1 grain under test
-            var stats = _storage as IStorageStats;
-            return stats?.Stats;
+            get
+            {
+                //There should only be one state in here since there is only 1 grain under test
+                var stats = _storage as IStorageStats;
+                return stats?.Stats;
+            }
         }
+
+        [Obsolete("Use StorageStats property")]
+        [SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Keeping for backwards compatibility.")]
+        public TestStorageStats GetStorageStats() =>
+            StorageStats;
     }
 }

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -3,23 +3,24 @@
 
   <PropertyGroup>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Orleans.TestKit.Tests</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FakeItEasy" Version="7.1.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.4.3" />
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.5.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/OrleansTestKit.Tests/Tests/BasicGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/BasicGrainTests.cs
@@ -38,7 +38,7 @@ namespace Orleans.TestKit.Tests
             await Silo.CreateGrainAsync<LifecycleGrain>(new Random().Next());
 
             Func<Task> creatingSecondGrainAsync = async () => await Silo.CreateGrainAsync<LifecycleGrain>(new Random().Next());
-            creatingSecondGrainAsync.Should().Throw<Exception>();
+            await creatingSecondGrainAsync.Should().ThrowAsync<Exception>();
         }
 
         [Fact]

--- a/test/OrleansTestKit.Tests/Tests/GrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/GrainProbeTests.cs
@@ -45,7 +45,7 @@ namespace Orleans.TestKit.Tests
             IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             //There should not be an exception, since we are using loose grain generation
-            grain.Invoking(p => p.Ping()).Should().NotThrow();
+            await grain.Invoking(p => p.Ping()).Should().NotThrowAsync();
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Orleans.TestKit.Tests
             //This uses the wrong id for the IPong since this is hard coded within PingGrain
             var pong = Silo.AddProbe<IPong>(0);
 
-            grain.Invoking(p => p.Ping()).Should().NotThrow();
+            await grain.Invoking(p => p.Ping()).Should().NotThrowAsync();
 
             pong.Verify(p => p.Pong(), Times.Never);
         }
@@ -69,7 +69,7 @@ namespace Orleans.TestKit.Tests
             //This correct id, but a different grain type
             var pong = Silo.AddProbe<IPong2>(22);
 
-            grain.Invoking(p => p.Ping()).Should().NotThrow();
+            await grain.Invoking(p => p.Ping()).Should().NotThrowAsync();
 
             pong.Verify(p => p.Pong2(), Times.Never);
         }
@@ -137,9 +137,9 @@ namespace Orleans.TestKit.Tests
 
             var pong = new Mock<IPong>();
 
-            this.Silo.AddProbe<IPong>(identity => pong);
+            Silo.AddProbe<IPong>(identity => pong);
 
-            var grain = await this.Silo.CreateGrainAsync<PingGrain>(1);
+            var grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
             await grain.Ping();
 
@@ -156,7 +156,7 @@ namespace Orleans.TestKit.Tests
             var secondUnknownGrain = new Mock<IUnknownGrain>();
             var probeQueue = new Queue<Mock<IUnknownGrain>>(new [] {firstUnknownGrain, secondUnknownGrain});
 
-            this.Silo.AddProbe<IUnknownGrain>(identity =>
+            Silo.AddProbe<IUnknownGrain>(identity =>
             {
                 var nextProbe = probeQueue.Dequeue();
 
@@ -166,7 +166,7 @@ namespace Orleans.TestKit.Tests
                 return nextProbe;
             });
 
-            var grain = await this.Silo.CreateGrainAsync<UnknownGrainResolver>("1");
+            var grain = await Silo.CreateGrainAsync<UnknownGrainResolver>("1");
 
             await grain.CreateAndPingMultiple();
 
@@ -183,7 +183,7 @@ namespace Orleans.TestKit.Tests
             var secondUnknownGrain = A.Fake<IUnknownGrain>();
             var probeQueue = new Queue<IUnknownGrain>(new[] { firstUnknownGrain, secondUnknownGrain });
 
-            this.Silo.AddProbe<IUnknownGrain>(identity =>
+            Silo.AddProbe<IUnknownGrain>(identity =>
             {
                 var nextProbe = probeQueue.Dequeue();
 
@@ -193,7 +193,7 @@ namespace Orleans.TestKit.Tests
                 return nextProbe;
             });
 
-            var grain = await this.Silo.CreateGrainAsync<UnknownGrainResolver>("1");
+            var grain = await Silo.CreateGrainAsync<UnknownGrainResolver>("1");
 
             await grain.CreateAndPingMultiple();
 
@@ -210,7 +210,7 @@ namespace Orleans.TestKit.Tests
             var secondUnknownGrain = Substitute.For<IUnknownGrain>();
             var probeQueue = new Queue<IUnknownGrain>(new[] { firstUnknownGrain, secondUnknownGrain });
 
-            this.Silo.AddProbe<IUnknownGrain>(identity =>
+            Silo.AddProbe<IUnknownGrain>(identity =>
             {
                 var nextProbe = probeQueue.Dequeue();
 
@@ -219,7 +219,7 @@ namespace Orleans.TestKit.Tests
                 return nextProbe;
             });
 
-            var grain = await this.Silo.CreateGrainAsync<UnknownGrainResolver>("1");
+            var grain = await Silo.CreateGrainAsync<UnknownGrainResolver>("1");
 
             await grain.CreateAndPingMultiple();
 
@@ -235,7 +235,7 @@ namespace Orleans.TestKit.Tests
             var androidMock = Silo.AddProbe<IDevice>("Android", "TestGrains.DeviceAndroidGrain");
             var iosMock = Silo.AddProbe<IDevice>("IOS", "TestGrains.DeviceIosGrain");
 
-            var managerGrain = await this.Silo.CreateGrainAsync<DeviceManagerGrain>(0);
+            var managerGrain = await Silo.CreateGrainAsync<DeviceManagerGrain>(0);
             var androidGrain = await managerGrain.GetDeviceGrain("Android");
             var iosGrain = await managerGrain.GetDeviceGrain("IOS");
 
@@ -251,7 +251,7 @@ namespace Orleans.TestKit.Tests
             var iosMock = Silo.AddProbe<IDevice>("IOS", "TestGrains.DeviceIosGrain");
             iosMock.Setup(o => o.GetDeviceType()).ReturnsAsync("BSD");
 
-            var managerGrain = await this.Silo.CreateGrainAsync<DeviceManagerGrain>(0);
+            var managerGrain = await Silo.CreateGrainAsync<DeviceManagerGrain>(0);
             var androidType = await managerGrain.GetDeviceType("Android");
             var iosType = await managerGrain.GetDeviceType("IOS");
 

--- a/test/OrleansTestKit.Tests/Tests/LoggerTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/LoggerTests.cs
@@ -23,7 +23,7 @@ namespace Orleans.TestKit.Tests
 
             IHello grain = await Silo.CreateGrainAsync<HelloGrain>(1);
 
-            grain.Invoking(g => g.SayHello(greeting)).Should().NotThrow();
+            await grain.Invoking(g => g.SayHello(greeting)).Should().NotThrowAsync();
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Orleans.TestKit.Tests
 
             IHello grain = await Silo.CreateGrainAsync<HelloGrain>(2);
 
-            grain.Invoking(g => g.SayHello(greeting)).Should().NotThrow();
+            await grain.Invoking(g => g.SayHello(greeting)).Should().NotThrowAsync();
         }
     }
 }

--- a/test/OrleansTestKit.Tests/Tests/ReminderTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ReminderTests.cs
@@ -135,7 +135,7 @@ namespace Orleans.TestKit.Tests
             Func<Task> f = async () => { await Silo.FireReminder("b"); };
 
             // Assert
-            f.Should().Throw<Exception>();
+            await f.Should().ThrowAsync<Exception>();
             grain.FiredReminders.Count.Should().Be(0);
         }
 

--- a/test/OrleansTestKit.Tests/Tests/StrictGrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StrictGrainProbeTests.cs
@@ -34,7 +34,7 @@ namespace Orleans.TestKit.Tests
         {
             IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
-            grain.Invoking(p => p.Ping()).Should().ThrowExactly<Exception>();
+            await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<Exception>();
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace Orleans.TestKit.Tests
             //This uses the wrong id for the IPong since this is hard coded within PingGrain
             var pong = Silo.AddProbe<IPong>(0);
 
-            grain.Invoking(p => p.Ping()).Should().ThrowExactly<Exception>();
+            await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<Exception>();
 
             pong.Verify(p => p.Pong(), Times.Never);
         }
@@ -58,7 +58,7 @@ namespace Orleans.TestKit.Tests
             //This uses the correct id, but the wrong grain type
             var pong = Silo.AddProbe<IPong2>(22);
 
-            grain.Invoking(p => p.Ping()).Should().ThrowExactly<Exception>();
+            await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<Exception>();
 
             pong.Verify(p => p.Pong2(), Times.Never);
         }


### PR DESCRIPTION
This updates the project to the latest .NET 5 SDK, and updates the test project to use a .NET 5 runtime. This also resolves & suppresses some additional code analysis warnings. The library target remains unchanged (.NET Standard 2.0).