### PR TITLE
pass thru the id, provider, generate a handleid, generate streamidentity

### DIFF
--- a/src/OrleansTestKit/Streams/TestStream.cs
+++ b/src/OrleansTestKit/Streams/TestStream.cs
@@ -80,21 +80,25 @@ namespace Orleans.TestKit.Streams
         {
             TestStreamSubscriptionHandle<T> handle = null;
 
-            handle = new TestStreamSubscriptionHandle<T>(observer =>
-            {
-                _handlers.Remove(handle);
-                if (observer != null)
+            handle = new TestStreamSubscriptionHandle<T>(
+                Guid,
+                Namespace,
+                ProviderName,
+                observer =>
+                {
+                    _handlers.Remove(handle);
+                    if (observer != null)
+                    {
+                        _observers.Remove(observer);
+                    }
+                }, observer =>
+                {
+                    onAttachingObserver?.Invoke(observer);
+                    _observers.Add(observer);
+                }, observer =>
                 {
                     _observers.Remove(observer);
-                }
-            }, observer =>
-            {
-                onAttachingObserver?.Invoke(observer);
-                _observers.Add(observer);
-            }, observer =>
-            {
-                _observers.Remove(observer);
-            });
+                });
 
             return handle;
         }

--- a/src/OrleansTestKit/Streams/TestStreamSubscriptionHandle.cs
+++ b/src/OrleansTestKit/Streams/TestStreamSubscriptionHandle.cs
@@ -11,15 +11,26 @@ namespace Orleans.TestKit.Streams
         private readonly Action<IAsyncObserver<T>> _unsubscribe;
         private readonly Action<IAsyncObserver<T>> _onAttachingObserver;
         private readonly Action<IAsyncObserver<T>> _onDetachingObserver;
+        private readonly Guid _handleId;
+        private readonly TestStreamId _streamIdentity;
+        private readonly string _providerName;
         private IAsyncObserver<T> _observer;
 
-        public TestStreamSubscriptionHandle(Action<IAsyncObserver<T>> unsubscribe,
+        public TestStreamSubscriptionHandle(
+            Guid streamId,
+            string streamNamespace,
+            string providerName,
+            Action<IAsyncObserver<T>> unsubscribe,
             Action<IAsyncObserver<T>> onAttachingObserver = null,
             Action<IAsyncObserver<T>> onDetachingObserver = null)
         {
             _unsubscribe = unsubscribe ?? throw new ArgumentNullException(nameof(unsubscribe));
             _onAttachingObserver = onAttachingObserver;
             _onDetachingObserver = onDetachingObserver;
+
+            _handleId = Guid.NewGuid();
+            _streamIdentity = new TestStreamId(streamId, streamNamespace);
+            _providerName = providerName;
         }
 
 
@@ -27,7 +38,7 @@ namespace Orleans.TestKit.Streams
         {
             get
             {
-                throw new NotImplementedException();
+                return _handleId;
             }
         }
 
@@ -35,7 +46,7 @@ namespace Orleans.TestKit.Streams
         {
             get
             {
-                throw new NotImplementedException();
+                return _providerName;
             }
         }
 
@@ -43,7 +54,7 @@ namespace Orleans.TestKit.Streams
         {
             get
             {
-                throw new NotImplementedException();
+                return _streamIdentity;
             }
         }
 

--- a/test/OrleansTestKit.Tests/Tests/StreamTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StreamTests.cs
@@ -209,5 +209,33 @@ namespace Orleans.TestKit.Tests
 
             (await grain.ReceivedCount()).Should().Be(1);
         }
+
+
+        [Fact]
+        public async Task SubscriptionHandlesShouldHaveIdentity()
+        {
+            var stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null);
+
+            await Silo.CreateGrainAsync<Listener>(1);
+            var handlers = await stream.GetAllSubscriptionHandles();
+
+            handlers.Count.Should().Be(1);
+            stream.Subscribed.Should().Be(1);
+
+
+            foreach (var handle in handlers)
+            {
+                handle.ProviderName.Should().Be("Default");
+                handle.HandleId.Should().NotBeEmpty();
+                handle.StreamIdentity.Should().NotBeNull();
+                handle.StreamIdentity.Namespace.Should().BeNull();
+            }
+
+            await handlers[0].UnsubscribeAsync();
+
+            handlers.Count.Should().Be(1);
+            stream.Subscribed.Should().Be(0);
+        }
+
     }
 }


### PR DESCRIPTION
This PR provides for retrieving the HandleId, ProviderName, and StreamIdentity when working with streams.   re: #116 we have logging routines which captured these values and would fail when testing using OrleansTestKit.