### PR TITLE
Changes to support NSubstitute for mocking.

### DIFF
--- a/src/OrleansTestKit/GrainProbeExtensions.cs
+++ b/src/OrleansTestKit/GrainProbeExtensions.cs
@@ -1,10 +1,73 @@
-﻿using Moq;
+﻿#if NSUBSTITUTE
+
+#else
+using Moq;
+#endif
+
 using Orleans.Runtime;
 
 namespace Orleans.TestKit;
 
 public static class GrainProbeExtensions
 {
+#if NSUBSTITUTE
+
+    public static T AddProbe<T>(this TestKitSilo silo, long id, string? classPrefix = null)
+        where T : class, IGrainWithIntegerKey
+    {
+        if (silo == null)
+        {
+            throw new ArgumentNullException(nameof(silo));
+        }
+
+        return silo.GrainFactory.AddProbe<T>(GrainIdKeyExtensions.CreateIntegerKey(id), classPrefix);
+    }
+
+    public static T AddProbe<T>(this TestKitSilo silo, Guid id, string? classPrefix = null)
+        where T : class, IGrainWithGuidKey
+    {
+        if (silo == null)
+        {
+            throw new ArgumentNullException(nameof(silo));
+        }
+
+        return silo.GrainFactory.AddProbe<T>(GrainIdKeyExtensions.CreateGuidKey(id), classPrefix);
+    }
+
+    public static T AddProbe<T>(this TestKitSilo silo, long id, string keyExtension, string? classPrefix = null)
+        where T : class, IGrainWithIntegerCompoundKey
+    {
+        if (silo == null)
+        {
+            throw new ArgumentNullException(nameof(silo));
+        }
+
+        return silo.GrainFactory.AddProbe<T>(GrainIdKeyExtensions.CreateIntegerKey(id, keyExtension), classPrefix);
+    }
+
+    public static T AddProbe<T>(this TestKitSilo silo, Guid id, string keyExtension, string? classPrefix = null)
+        where T : class, IGrainWithGuidCompoundKey
+    {
+        if (silo == null)
+        {
+            throw new ArgumentNullException(nameof(silo));
+        }
+
+        return silo.GrainFactory.AddProbe<T>(GrainIdKeyExtensions.CreateGuidKey(id, keyExtension), classPrefix);
+    }
+
+    public static T AddProbe<T>(this TestKitSilo silo, string id, string? classPrefix = null)
+        where T : class, IGrainWithStringKey
+    {
+        if (silo == null)
+        {
+            throw new ArgumentNullException(nameof(silo));
+        }
+
+        return silo.GrainFactory.AddProbe<T>(IdSpan.Create(id), classPrefix);
+    }
+
+#else
     public static Mock<T> AddProbe<T>(this TestKitSilo silo, long id, string? classPrefix = null)
         where T : class, IGrainWithIntegerKey
     {
@@ -70,6 +133,8 @@ public static class GrainProbeExtensions
 
         silo.GrainFactory.AddProbe(factory);
     }
+
+#endif
 
     public static void AddProbe<T>(this TestKitSilo silo, Func<IdSpan, T> factory)
         where T : class, IGrain

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -19,19 +19,24 @@
     <RootNamespace>Orleans.TestKit</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Flavor)'=='nsubstitute'">
+    <PackageId>$(AssemblyName).NSubstitute</PackageId>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.1.0" />
     <PackageReference Include="Microsoft.Orleans.Streaming" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Runtime" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" Version="7.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" Condition="'$(Flavor)'=='nsubstitute'"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -41,5 +46,10 @@
   <ItemGroup>
     <None Include="$(ProjectRoot)assets/logo_128.png" Pack="true" Visible="false" PackagePath="/" />
   </ItemGroup>
+
+
+  <PropertyGroup Condition="'$(Flavor)'=='nsubstitute'">
+    <DefineConstants>$(DefineConstants);NSUBSTITUTE</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/OrleansTestKit/Reminders/TestReminderRegistry.cs
+++ b/src/OrleansTestKit/Reminders/TestReminderRegistry.cs
@@ -1,4 +1,11 @@
-﻿using Moq;
+﻿#if NSUBSTITUTE
+
+using NSubstitute;
+
+#else
+using Moq;
+#endif
+
 using Orleans.Runtime;
 using Orleans.Timers;
 
@@ -10,7 +17,13 @@ public sealed class TestReminderRegistry : IReminderRegistry
 
     private IRemindable _grain;
 
+#if NSUBSTITUTE
+
+    public IReminderRegistry Mock { get; } = Substitute.For<IReminderRegistry>();
+
+#else
     public Mock<IReminderRegistry> Mock { get; } = new();
+#endif
 
     public async Task FireAllReminders(TickStatus tickStatus)
     {
@@ -42,13 +55,22 @@ public sealed class TestReminderRegistry : IReminderRegistry
             throw new ArgumentNullException(nameof(reminderName));
         }
 
+#if NSUBSTITUTE
+        await Mock.GetReminder(callingGrainId, reminderName);
+#else
         await Mock.Object.GetReminder(callingGrainId, reminderName);
+#endif
         return !_reminders.TryGetValue(reminderName, out var reminder) ? null : reminder;
     }
 
     public async Task<List<IGrainReminder>> GetReminders(GrainId callingGrainId)
     {
+#if NSUBSTITUTE
+        await Mock.GetReminders(callingGrainId);
+#else
         await Mock.Object.GetReminders(callingGrainId);
+#endif
+
         return _reminders.Values.ToList<IGrainReminder>();
     }
 
@@ -58,8 +80,11 @@ public sealed class TestReminderRegistry : IReminderRegistry
         {
             throw new ArgumentNullException(nameof(reminderName));
         }
-
+#if NSUBSTITUTE
+        await Mock.RegisterOrUpdateReminder(callingGrainId, reminderName, dueTime, period);
+#else
         await Mock.Object.RegisterOrUpdateReminder(callingGrainId, reminderName, dueTime, period);
+#endif
         var reminder = new TestReminder(reminderName, dueTime, period);
         _reminders[reminderName] = reminder;
         return reminder;
@@ -72,7 +97,11 @@ public sealed class TestReminderRegistry : IReminderRegistry
             throw new ArgumentNullException(nameof(reminder));
         }
 
+#if NSUBSTITUTE
+        await Mock.UnregisterReminder(callingGrainId, reminder);
+#else
         await Mock.Object.UnregisterReminder(callingGrainId, reminder);
+#endif
         _reminders.Remove(reminder.ReminderName);
     }
 

--- a/src/OrleansTestKit/Services/TestServiceProvider.cs
+++ b/src/OrleansTestKit/Services/TestServiceProvider.cs
@@ -1,4 +1,11 @@
-﻿using Moq;
+﻿#if NSUBSTITUTE
+
+using NSubstitute;
+using NSubstitute.Core;
+
+#else
+using Moq;
+#endif
 
 namespace Orleans.TestKit.Services;
 
@@ -25,6 +32,30 @@ public sealed class TestServiceProvider : IServiceProvider
         return instance;
     }
 
+#if NSUBSTITUTE
+
+    public T AddServiceProbe<T>(T mock)
+        where T : class
+    {
+        if (mock == null && typeof(T) is not ICallRouterProvider)
+        {
+            throw new ArgumentNullException(nameof(mock));
+        }
+
+        _services.Add(typeof(T), mock);
+        return mock;
+    }
+
+    public T AddServiceProbe<T>()
+        where T : class
+    {
+        var mock = Substitute.For<T>();
+        _services.Add(typeof(T), mock);
+        return mock;
+    }
+
+#else
+
     public Mock<T> AddServiceProbe<T>(Mock<T> mock)
         where T : class
     {
@@ -44,6 +75,7 @@ public sealed class TestServiceProvider : IServiceProvider
         _services.Add(typeof(T), mock.Object);
         return mock;
     }
+#endif
 
     public object GetService(Type serviceType)
     {
@@ -65,12 +97,17 @@ public sealed class TestServiceProvider : IServiceProvider
         else
         {
             // Create a new mock
+#if NSUBSTITUTE
+            if (Substitute.For(new[] { serviceType }, null) is not ICallRouterProvider mock)
+#else
             if (Activator.CreateInstance(typeof(Mock<>).MakeGenericType(serviceType)) is not IMock<object> mock)
+#endif
+
             {
                 throw new Exception($"Failed to instantiate {serviceType.Name}.");
             }
 
-            service = mock.Object;
+            service = mock;
 
             // Save the newly created grain for the next call
             _services.Add(serviceType, service);

--- a/src/OrleansTestKit/Services/TestServicesExtensions.cs
+++ b/src/OrleansTestKit/Services/TestServicesExtensions.cs
@@ -1,4 +1,8 @@
-﻿using Moq;
+﻿#if NSUBSTITUTE
+
+#else
+using Moq;
+#endif
 
 namespace Orleans.TestKit;
 
@@ -15,7 +19,32 @@ public static class TestServicesExtensions
         return silo.ServiceProvider.AddService(instance);
     }
 
-    public static Mock<T> AddServiceProbe<T>(this TestKitSilo silo)
+#if NSUBSTITUTE
+
+    public static T AddServiceProbe<T>(this TestKitSilo silo)
+            where T : class
+    {
+        if (silo == null)
+        {
+            throw new ArgumentNullException(nameof(silo));
+        }
+
+        return silo.ServiceProvider.AddServiceProbe<T>();
+    }
+
+    public static T AddServiceProbe<T>(this TestKitSilo silo, T mock)
+        where T : class
+    {
+        if (silo == null)
+        {
+            throw new ArgumentNullException(nameof(silo));
+        }
+
+        return silo.ServiceProvider.AddServiceProbe(mock);
+    }
+
+#else
+public static Mock<T> AddServiceProbe<T>(this TestKitSilo silo)
         where T : class
     {
         if (silo == null)
@@ -36,4 +65,5 @@ public static class TestServicesExtensions
 
         return silo.ServiceProvider.AddServiceProbe(mock);
     }
+#endif
 }

--- a/src/OrleansTestKit/TestGrainRuntime.cs
+++ b/src/OrleansTestKit/TestGrainRuntime.cs
@@ -1,4 +1,11 @@
-﻿using Moq;
+﻿#if NSUBSTITUTE
+
+using NSubstitute;
+
+#else
+using Moq;
+#endif
+
 using Orleans.Core;
 using Orleans.Runtime;
 using Orleans.TestKit.Storage;
@@ -6,7 +13,7 @@ using Orleans.Timers;
 
 namespace Orleans.TestKit;
 
-internal sealed class TestGrainRuntime : IGrainRuntime
+public sealed class TestGrainRuntime : IGrainRuntime
 {
     private readonly StorageManager _storageManager;
 
@@ -21,7 +28,14 @@ internal sealed class TestGrainRuntime : IGrainRuntime
 
     public IGrainFactory GrainFactory { get; }
 
+#if NSUBSTITUTE
+
+    public IGrainRuntime Mock { get; } = Substitute.For<IGrainRuntime>();
+
+#else
     public Mock<IGrainRuntime> Mock { get; } = new Mock<IGrainRuntime>();
+
+#endif
 
     public IReminderRegistry ReminderRegistry { get; }
 
@@ -42,7 +56,11 @@ internal sealed class TestGrainRuntime : IGrainRuntime
             throw new ArgumentNullException(nameof(grain));
         }
 
+#if NSUBSTITUTE
+        Mock.DeactivateOnIdle(grain);
+#else
         Mock.Object.DeactivateOnIdle(grain);
+#endif
     }
 
     public void DelayDeactivation(IGrainContext grain, TimeSpan timeSpan)
@@ -51,8 +69,11 @@ internal sealed class TestGrainRuntime : IGrainRuntime
         {
             throw new ArgumentNullException(nameof(grain));
         }
-
+#if NSUBSTITUTE
+        Mock.DelayDeactivation(grain, timeSpan);
+#else
         Mock.Object.DelayDeactivation(grain, timeSpan);
+#endif
     }
 
     public IStorage<TGrainState> GetStorage<TGrainState>(IGrainContext grain) =>

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -1,6 +1,16 @@
 ﻿using System.Collections.ObjectModel;
-using System.Linq.Expressions;
+
+#if NSUBSTITUTE
+
+using NSubstitute;
+
+#else
+
 using Moq;
+using System.Linq.Expressions;
+
+#endif
+
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestKit.Reminders;
@@ -47,6 +57,8 @@ public sealed class TestKitSilo
     ///     the grain, not any test code.
     /// </summary>
     public TestGrainFactory GrainFactory { get; }
+
+    public TestGrainRuntime GrainRuntime => _grainRuntime;
 
     /// <summary>Gets the test silo options.</summary>
     public TestKitOptions Options { get; } = new();
@@ -140,8 +152,14 @@ public sealed class TestKitSilo
         return handler;
     }
 
+#if NSUBSTITUTE
+
+#else
+
     public void VerifyRuntime(Expression<Action<IGrainRuntime>> expression, Func<Times> times) =>
         _grainRuntime.Mock.Verify(expression, times);
+
+#endif
 
     private async Task<T> CreateGrainAsync<T>(IdSpan identity, CancellationToken cancellation = default) where T : Grain
     {

--- a/src/OrleansTestKit/Timers/TestTimerRegistry.cs
+++ b/src/OrleansTestKit/Timers/TestTimerRegistry.cs
@@ -1,4 +1,11 @@
-﻿using Moq;
+﻿#if NSUBSTITUTE
+
+using NSubstitute;
+
+#else
+using Moq;
+#endif
+
 using Orleans.Runtime;
 using Orleans.Timers;
 
@@ -8,7 +15,13 @@ public sealed class TestTimerRegistry : ITimerRegistry
 {
     private readonly List<TestTimer> _timers = new();
 
+#if NSUBSTITUTE
+
+    public ITimerRegistry Mock { get; } = Substitute.For<ITimerRegistry>();
+
+#else
     public Mock<ITimerRegistry> Mock { get; } = new();
+#endif
 
     public int NumberOfActiveTimers => _timers.Count(x => !x.IsDisposed);
 
@@ -29,8 +42,11 @@ public sealed class TestTimerRegistry : ITimerRegistry
         {
             throw new ArgumentNullException(nameof(grainContext));
         }
-
+#if NSUBSTITUTE
+        Mock.RegisterTimer(grainContext, asyncCallback, state, dueTime, period);
+#else
         Mock.Object.RegisterTimer(grainContext, asyncCallback, state, dueTime, period);
+#endif
         var timer = new TestTimer(asyncCallback, state);
         _timers.Add(timer);
         return timer;

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="17.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.0" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.analyzers" Version="1.1.0" />
@@ -24,5 +24,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrleansTestKit\OrleansTestKit.csproj" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(Flavor)'=='nsubstitute'">
+    <DefineConstants>$(DefineConstants);NSUBSTITUTE</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/test/OrleansTestKit.Tests/Tests/DeactivationGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/DeactivationGrainTests.cs
@@ -1,4 +1,11 @@
-﻿using Moq;
+﻿#if NSUBSTITUTE
+
+using NSubstitute;
+
+#else
+using Moq;
+#endif
+
 using TestGrains;
 using Xunit;
 
@@ -18,7 +25,11 @@ public class DeactivationGrainTests : TestKitBase
         var context = Silo.GetContextFromGrain(grain);
 
         // Assert
+#if NSUBSTITUTE
+        Silo.GrainRuntime.Mock.Received(1).DeactivateOnIdle(context);
+#else
         Silo.VerifyRuntime(i => i.DeactivateOnIdle(context), Times.Once);
+#endif
     }
 
     [Fact]
@@ -34,6 +45,10 @@ public class DeactivationGrainTests : TestKitBase
         var context = Silo.GetContextFromGrain(grain);
 
         // Assert
-        Silo.VerifyRuntime(i => i.DelayDeactivation(context, timeSpan), Times.Once);
+#if NSUBSTITUTE
+        Silo.GrainRuntime.Mock.Received(1).DelayDeactivation(context, timeSpan);
+#else
+Silo.VerifyRuntime(i => i.DelayDeactivation(context, timeSpan), Times.Once);
+#endif
     }
 }

--- a/test/OrleansTestKit.Tests/Tests/ReminderTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ReminderTests.cs
@@ -1,5 +1,13 @@
 ﻿using FluentAssertions;
+
+#if NSUBSTITUTE
+
+using NSubstitute;
+
+#else
 using Moq;
+#endif
+
 using Orleans.Runtime;
 using TestGrains;
 using Xunit;
@@ -26,7 +34,11 @@ public class ReminderTests : TestKitBase
         }
 
         // Assert
+#if NSUBSTITUTE
+        Silo.ReminderRegistry.Mock.Received().RegisterOrUpdateReminder(Silo.GetGrainId(grain), reminderName, due, period);
+#else
         Silo.ReminderRegistry.Mock.Verify(x => x.RegisterOrUpdateReminder(Silo.GetGrainId(grain), reminderName, due, period));
+#endif
     }
 
     [Fact]
@@ -151,7 +163,11 @@ public class ReminderTests : TestKitBase
         }
 
         // Assert
+#if NSUBSTITUTE
+        Silo.ReminderRegistry.Mock.Received().UnregisterReminder(Silo.GetGrainId(grain), Arg.Is<IGrainReminder>(r => r.ReminderName == reminderName));
+#else
         Silo.ReminderRegistry.Mock.Verify(x => x.UnregisterReminder(Silo.GetGrainId(grain), It.Is<IGrainReminder>(r => r.ReminderName == reminderName)));
+#endif
     }
 
     [Fact]
@@ -167,6 +183,10 @@ public class ReminderTests : TestKitBase
         }
 
         // Assert
+#if NSUBSTITUTE
+        Silo.ReminderRegistry.Mock.Received(1).GetReminder(Silo.GetGrainId(grain), "a");
+#else
         Silo.ReminderRegistry.Mock.Verify(v => v.GetReminder(Silo.GetGrainId(grain), "a"), Times.Once);
+#endif
     }
 }

--- a/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
@@ -1,6 +1,15 @@
 ﻿using System.Reflection;
 using FluentAssertions;
+
+#if NSUBSTITUTE
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+#else
 using Moq;
+#endif
+
 using Orleans.Runtime;
 using Orleans.Storage;
 using TestGrains;
@@ -18,7 +27,15 @@ public class StorageFacetTests : TestKitBase
     {
         // Arrange
         var state = new ColorGrainState();
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
 
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
 
@@ -26,7 +43,7 @@ public class StorageFacetTests : TestKitBase
         mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
 
         Silo.AddService(mockMapper.Object);
-
+#endif
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
         // Act
@@ -46,6 +63,15 @@ public class StorageFacetTests : TestKitBase
             Id = GrainId,
         };
 
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
+
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
 
@@ -53,7 +79,7 @@ public class StorageFacetTests : TestKitBase
         mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
 
         Silo.AddService(mockMapper.Object);
-
+#endif
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
         // Act
@@ -68,7 +94,15 @@ public class StorageFacetTests : TestKitBase
     {
         // Arrange
         var state = new ColorGrainState();
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
 
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
 
@@ -76,6 +110,7 @@ public class StorageFacetTests : TestKitBase
         mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
 
         Silo.AddService(mockMapper.Object);
+#endif
 
         // Act
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
@@ -90,7 +125,15 @@ public class StorageFacetTests : TestKitBase
     {
         // Arrange
         var state = new ColorGrainState();
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
 
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
         mockState.Setup(o => o.ClearStateAsync());
@@ -99,6 +142,7 @@ public class StorageFacetTests : TestKitBase
         mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
 
         Silo.AddService(mockMapper.Object);
+#endif
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -112,7 +156,11 @@ public class StorageFacetTests : TestKitBase
         // Note that the following assert ties this test to the _implementation_ details. Generally, one should try to
         // avoid tying the test to the implementation details. It can lead to more brittle tests. However, one may
         // choose to accept this as a trade-off when the implementation detail represents an important behavior.
+#if NSUBSTITUTE
+        mockState.DidNotReceive().ClearStateAsync();
+#else
         mockState.Verify(o => o.ClearStateAsync(), Times.Never);
+#endif
     }
 
     [Fact]
@@ -125,6 +173,16 @@ public class StorageFacetTests : TestKitBase
             Id = GrainId,
         };
 
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
+        mockState.ClearStateAsync();
+
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
         mockState.Setup(o => o.ClearStateAsync());
@@ -134,13 +192,18 @@ public class StorageFacetTests : TestKitBase
 
         Silo.AddService(mockMapper.Object);
 
+#endif
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
         // Act
         await grain.ResetColor();
 
         // Assert
+#if NSUBSTITUTE
+        mockState.Received().ClearStateAsync();
+#else
         mockState.Verify(o => o.ClearStateAsync(), Times.Once);
+#endif
     }
 
     [Fact]
@@ -148,7 +211,15 @@ public class StorageFacetTests : TestKitBase
     {
         // Arrange
         var state = new ColorGrainState();
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
 
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
         mockState.Setup(o => o.WriteStateAsync());
@@ -157,7 +228,7 @@ public class StorageFacetTests : TestKitBase
         mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
 
         Silo.AddService(mockMapper.Object);
-
+#endif
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
         // Act
@@ -175,7 +246,15 @@ public class StorageFacetTests : TestKitBase
     {
         // Arrange
         var state = new ColorGrainState();
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
 
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
         mockState.Setup(o => o.WriteStateAsync());
@@ -184,6 +263,7 @@ public class StorageFacetTests : TestKitBase
         mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
 
         Silo.AddService(mockMapper.Object);
+#endif
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
         Action action = () => grain.SetColor(color);
@@ -198,7 +278,16 @@ public class StorageFacetTests : TestKitBase
     {
         // Arrange
         var state = new ColorGrainState();
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
+        mockState.WriteStateAsync().Throws<InconsistentStateException>();
 
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
         mockState.Setup(o => o.WriteStateAsync()).Throws<InconsistentStateException>();
@@ -207,7 +296,7 @@ public class StorageFacetTests : TestKitBase
         mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
 
         Silo.AddService(mockMapper.Object);
-
+#endif
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
         Action action = () => grain.SetColor(Color.Green);
 
@@ -224,7 +313,16 @@ public class StorageFacetTests : TestKitBase
             Color = Color.Red,
             Id = GrainId,
         };
+#if NSUBSTITUTE
+        var mockState = Substitute.For<IPersistentState<ColorGrainState>>();
+        mockState.State.Returns(state);
+        mockState.ClearStateAsync();
 
+        var mockMapper = Substitute.For<IAttributeToFactoryMapper<PersistentStateAttribute>>();
+        mockMapper.GetFactory(Arg.Any<ParameterInfo>(), Arg.Any<PersistentStateAttribute>()).Returns(context => mockState);
+
+        Silo.AddService(mockMapper);
+#else
         var mockState = new Mock<IPersistentState<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
         mockState.Setup(o => o.ClearStateAsync());
@@ -233,7 +331,7 @@ public class StorageFacetTests : TestKitBase
         mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
 
         Silo.AddService(mockMapper.Object);
-
+#endif
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
         // Act

--- a/test/OrleansTestKit.Tests/Tests/StrictGrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StrictGrainProbeTests.cs
@@ -1,5 +1,13 @@
 ﻿using FluentAssertions;
+
+#if NSUBSTITUTE
+
+using NSubstitute;
+
+#else
 using Moq;
+#endif
+
 using TestGrains;
 using TestInterfaces;
 using Xunit;
@@ -23,8 +31,11 @@ public class StrictGrainProbeTests : TestKitBase
         var pong = Silo.AddProbe<IPong>(0);
 
         await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<Exception>();
-
+#if NSUBSTITUTE
+        pong.DidNotReceive().Pong();
+#else
         pong.Verify(p => p.Pong(), Times.Never);
+#endif
     }
 
     [Fact]
@@ -37,7 +48,11 @@ public class StrictGrainProbeTests : TestKitBase
 
         await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<Exception>();
 
+#if NSUBSTITUTE
+        pong.DidNotReceive().Pong2();
+#else
         pong.Verify(p => p.Pong2(), Times.Never);
+#endif
     }
 
     [Fact]
@@ -57,6 +72,10 @@ public class StrictGrainProbeTests : TestKitBase
 
         await grain.Ping();
 
+#if NSUBSTITUTE
+        pong.Received(1).Pong();
+#else
         pong.Verify(p => p.Pong(), Times.Once);
+#endif
     }
 }


### PR DESCRIPTION
While OrleansTestKit team decides on real adaptability for supporting multiple mocking frameworks, I've added changes to support NSubstitute for mocking. 

To build a package for NSubstitute:

```
dotnet pack -c Release -p:Flavor=nsubstitute
```

To build package for Moq:
```
dotnet pack -c Release 
```

This is not best and elegant solution for maintenance preceptive, but I will try my best.