### PR TITLE
Streaming Improvements - String-Based Stream Probes and Batch Observer Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -544,3 +544,6 @@ tab_width = 4
 end_of_line = crlf
 dotnet_diagnostic.CA1002.severity = silent
 dotnet_diagnostic.CA1030.severity = silent
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = silent

--- a/src/OrleansTestKit/Streams/StreamExtensions.cs
+++ b/src/OrleansTestKit/Streams/StreamExtensions.cs
@@ -3,32 +3,104 @@ using Orleans.TestKit.Streams;
 
 namespace Orleans.TestKit;
 
+/// <summary>
+/// Extensions for adding stream probes to the TestKitSilo
+/// </summary>
 public static class StreamExtensions
 {
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <returns>The stream probe</returns>
     public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo) =>
         AddStreamProbe<T>(silo, Guid.Empty);
 
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <param name="id">The stream id.</param>
+    /// <returns>The stream probe</returns>
     public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, Guid id) =>
         AddStreamProbe<T>(silo, id, typeof(T).Name);
 
-    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, Guid id, string streamNamespace) =>
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <param name="id">The stream id.</param>
+    /// <param name="streamNamespace">The stream namespace.</param>
+    /// <returns>The stream probe</returns>
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, Guid id, string? streamNamespace) =>
         AddStreamProbe<T>(silo, id, streamNamespace, "Default");
 
-    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, Guid id, string streamNamespace, string providerName) =>
-        AddStreamProbe<T>(silo, StreamId.Create(streamNamespace, id), providerName);
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <param name="id">The stream id.</param>
+    /// <param name="streamNamespace">The stream namespace.</param>
+    /// <param name="providerName">The stream provider</param>
+    /// <returns>The stream probe</returns>
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, Guid id, string? streamNamespace, string providerName) =>
+        AddStreamProbe<T>(silo, StreamId.Create(streamNamespace ?? string.Empty, id), providerName);
 
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <param name="id">The stream id.</param>
+    /// <returns>The stream probe</returns>
     public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, string id) =>
         AddStreamProbe<T>(silo, id, typeof(T).Name);
 
-    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, string id, string streamNamespace) =>
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <param name="id">The stream id.</param>
+    /// <param name="streamNamespace">The stream namespace.</param>
+    /// <returns>The stream probe</returns>
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, string id, string? streamNamespace) =>
         AddStreamProbe<T>(silo, id, streamNamespace, "Default");
 
-    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, string id, string streamNamespace, string providerName) =>
-        AddStreamProbe<T>(silo, StreamId.Create(streamNamespace, id), providerName);
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <param name="id">The stream id.</param>
+    /// <param name="streamNamespace">The stream namespace.</param>
+    /// <param name="providerName">The stream provider</param>
+    /// <returns>The stream probe</returns>
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, string id, string? streamNamespace, string providerName) =>
+        AddStreamProbe<T>(silo, StreamId.Create(streamNamespace ?? string.Empty, id), providerName);
 
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <param name="id">The stream id.</param>
+    /// <returns>The stream probe</returns>
     public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, StreamId id) =>
         AddStreamProbe<T>(silo, id, "Default");
 
+    /// <summary>
+    /// Adds a stream probe for Guid.Empty
+    /// </summary>
+    /// <typeparam name="T">The stream type.</typeparam>
+    /// <param name="silo">The test kit silo.</param>
+    /// <param name="id">The stream id.</param>
+    /// <param name="providerName">The stream provider</param>
+    /// <returns>The stream probe</returns>
     public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, StreamId id, string providerName)
     {
         if (silo == null)

--- a/src/OrleansTestKit/Streams/StreamExtensions.cs
+++ b/src/OrleansTestKit/Streams/StreamExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Orleans.TestKit.Streams;
+﻿using Orleans.Runtime;
+using Orleans.TestKit.Streams;
 
 namespace Orleans.TestKit;
 
@@ -13,7 +14,22 @@ public static class StreamExtensions
     public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, Guid id, string streamNamespace) =>
         AddStreamProbe<T>(silo, id, streamNamespace, "Default");
 
-    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, Guid id, string streamNamespace, string providerName)
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, Guid id, string streamNamespace, string providerName) =>
+        AddStreamProbe<T>(silo, StreamId.Create(streamNamespace, id), providerName);
+
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, string id) =>
+        AddStreamProbe<T>(silo, id, typeof(T).Name);
+
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, string id, string streamNamespace) =>
+        AddStreamProbe<T>(silo, id, streamNamespace, "Default");
+
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, string id, string streamNamespace, string providerName) =>
+        AddStreamProbe<T>(silo, StreamId.Create(streamNamespace, id), providerName);
+
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, StreamId id) =>
+        AddStreamProbe<T>(silo, id, "Default");
+
+    public static TestStream<T> AddStreamProbe<T>(this TestKitSilo silo, StreamId id, string providerName)
     {
         if (silo == null)
         {
@@ -25,6 +41,6 @@ public static class StreamExtensions
             throw new ArgumentNullException(nameof(providerName));
         }
 
-        return silo.StreamProviderManager.AddStreamProbe<T>(id, streamNamespace, providerName);
+        return silo.StreamProviderManager.AddStreamProbe<T>(id, providerName);
     }
 }

--- a/src/OrleansTestKit/Streams/TestStreamProviderManager.cs
+++ b/src/OrleansTestKit/Streams/TestStreamProviderManager.cs
@@ -15,6 +15,9 @@ public sealed class TestStreamProviderManager : IKeyedServiceCollection<string, 
     public TestStream<T> AddStreamProbe<T>(Guid streamId, string ns, string providerName) =>
         AddStreamProbe<T>(StreamId.Create(ns, streamId), providerName);
 
+    public TestStream<T> AddStreamProbe<T>(string streamId, string ns, string providerName) =>
+        AddStreamProbe<T>(StreamId.Create(ns, streamId), providerName);
+
     public TestStream<T> AddStreamProbe<T>(StreamId streamId, string providerName)
     {
         var provider = GetOrAdd(providerName);

--- a/src/OrleansTestKit/Streams/TestStreamSubscriptionHandle.cs
+++ b/src/OrleansTestKit/Streams/TestStreamSubscriptionHandle.cs
@@ -3,89 +3,67 @@ using Orleans.Streams;
 
 namespace Orleans.TestKit.Streams;
 
-internal sealed class TestStreamSubscriptionHandle<T> : StreamSubscriptionHandle<T>
+internal sealed class TestStreamSubscriptionHandle<TObserver, T> : StreamSubscriptionHandle<T>
+    where TObserver : class
 {
-    private readonly Guid _handleId;
-
-    private readonly Action<IAsyncObserver<T>>? _onAttachingObserver;
-
-    private readonly Action<IAsyncObserver<T>>? _onDetachingObserver;
-
-    private readonly string _providerName;
+    private readonly Guid _handleId = Guid.NewGuid();
 
     private readonly StreamId _streamIdentity;
+    private readonly string _providerName;
+    private readonly Action<TObserver> _onAttaching;
+    private readonly Action<TObserver> _onDetaching;
+    private readonly Action<TObserver> _unsubscribe;
 
-    private readonly Action<IAsyncObserver<T>> _unsubscribe;
+    private TObserver? _observer;
 
-    private IAsyncObserver<T>? _observer;
-
-    public TestStreamSubscriptionHandle(
-        StreamId streamId,
-        string providerName,
-        Action<IAsyncObserver<T>> unsubscribe,
-        Action<IAsyncObserver<T>>? onAttachingObserver = null,
-        Action<IAsyncObserver<T>>? onDetachingObserver = null)
+    public TestStreamSubscriptionHandle(StreamId streamId, string providerName, Action<TObserver> unsubscribe, Action<TObserver> onAttaching, Action<TObserver> onDetaching)
     {
-        _unsubscribe = unsubscribe ?? throw new ArgumentNullException(nameof(unsubscribe));
-        _onAttachingObserver = onAttachingObserver;
-        _onDetachingObserver = onDetachingObserver;
-
-        _handleId = Guid.NewGuid();
         _streamIdentity = streamId;
         _providerName = providerName;
+        _unsubscribe = unsubscribe;
+        _onAttaching = onAttaching;
+        _onDetaching = onDetaching;
     }
 
-    public override Guid HandleId =>
-        _handleId;
+    public override Guid HandleId => _handleId;
 
-    public override string ProviderName =>
-        _providerName;
+    public override string ProviderName => _providerName;
 
-    public override StreamId StreamId =>
-        _streamIdentity;
+    public override StreamId StreamId => _streamIdentity;
 
-    public void AttachObserver(IAsyncObserver<T> observer)
+    public override bool Equals(StreamSubscriptionHandle<T> other) => ReferenceEquals(this, other);
+
+    public override Task<StreamSubscriptionHandle<T>> ResumeAsync(IAsyncObserver<T> observer, StreamSequenceToken? token = null) => ResumeGenericAsync(observer);
+
+    public override Task<StreamSubscriptionHandle<T>> ResumeAsync(IAsyncBatchObserver<T> observer, StreamSequenceToken? token = null) => ResumeGenericAsync(observer);
+
+    private Task<StreamSubscriptionHandle<T>> ResumeGenericAsync(object observer)
     {
-        if (_observer != null)
-        {
-            throw new Exception("You can only have one observer per handler");
-        }
+        if (observer is not TObserver typedObserver)
+            throw new InvalidOperationException($"Subscription resumed with {observer.GetType().Name} but stream probe is of type {typeof(TObserver).Name}");
 
-        _observer = observer;
-        _onAttachingObserver?.Invoke(observer);
-    }
-
-    public void DetachCurrentObserver()
-    {
-        if (_observer == null)
-        {
-            return;
-        }
-
-        _onDetachingObserver?.Invoke(_observer);
-        _observer = null;
-    }
-
-    public override bool Equals(StreamSubscriptionHandle<T> other) =>
-        ReferenceEquals(this, other);
-
-    public override Task<StreamSubscriptionHandle<T>> ResumeAsync(
-        IAsyncObserver<T> observer,
-        StreamSequenceToken? token = null)
-    {
         DetachCurrentObserver();
-        AttachObserver(observer);
+        _observer = typedObserver;
+        _onAttaching(_observer);
         return Task.FromResult<StreamSubscriptionHandle<T>>(this);
     }
 
-    public override Task<StreamSubscriptionHandle<T>> ResumeAsync(
-        IAsyncBatchObserver<T> observer,
-        StreamSequenceToken? token = null) =>
-        throw new NotImplementedException();
-
     public override Task UnsubscribeAsync()
     {
-        _unsubscribe?.Invoke(_observer!);
+        if (_observer is not null)
+        {
+            _unsubscribe(_observer);
+        }
+
         return Task.CompletedTask;
+    }
+
+    private void DetachCurrentObserver()
+    {
+        if (_observer is not null)
+        {
+            _onDetaching(_observer);
+            _observer = null;
+        }
     }
 }

--- a/test/OrleansTestKit.Tests/Grains/Chatty.cs
+++ b/test/OrleansTestKit.Tests/Grains/Chatty.cs
@@ -3,42 +3,57 @@ using TestInterfaces;
 
 namespace TestGrains;
 
+public readonly record struct ChattyMessage(string Message, int Id);
+
 public class Chatty : Grain, IChatty
 {
-    private (string Message, int Id) _recievedMessage;
+    private ChattyMessage _recievedMessage;
 
-    private StreamSubscriptionHandle<(string Message, int Id)> _subscription;
+    private StreamSubscriptionHandle<ChattyMessage>? _subscription;
 
-    public Task<(string Message, int Id)> GetMessage()
+    public Task<ChattyMessage> GetMessage()
     {
         return Task.FromResult(_recievedMessage);
     }
 
+    protected IStreamProvider Provider => this.GetStreamProvider("Default");
+    protected IAsyncStream<ChattyMessage> ChattyStream => Provider.GetStream<ChattyMessage>(Guid.Empty);
+
     public async Task SendChat(string msg)
     {
-        var provider = this.GetStreamProvider("Default");
-
-        var stream = provider.GetStream<ChatMessage>(Guid.Empty);
+        var stream = Provider.GetStream<ChatMessage>(Guid.Empty);
 
         await stream.OnNextAsync(new ChatMessage(msg));
     }
 
-    public async Task SendChatBatch(params string[] chats)
+    public async Task SendChatBatch(params string[] msgs)
     {
-        var provider = this.GetStreamProvider("Default");
+        var stream = Provider.GetStream<ChatMessage>(Guid.Empty);
 
-        var stream = provider.GetStream<ChatMessage>(Guid.Empty);
-
-        await stream.OnNextBatchAsync(chats.Select(chat => new ChatMessage(chat)));
+        await stream.OnNextBatchAsync(msgs.Select(chat => new ChatMessage(chat)));
     }
 
     public async Task Subscribe()
     {
-        var provider = this.GetStreamProvider("Default");
-        var stream = provider.GetStream<(string Message, int Id)>(Guid.Empty);
-        _subscription = await stream.SubscribeAsync(async (item, _) =>
+        _subscription = await ChattyStream.SubscribeAsync(async (item, _) =>
         {
             _recievedMessage = item;
+            if ("goodbye".Equals(_recievedMessage.Message, StringComparison.OrdinalIgnoreCase))
+            {
+                if (_subscription != null)
+                {
+                    await _subscription.UnsubscribeAsync();
+                    _subscription = null;
+                }
+            }
+        });
+    }
+
+    public async Task SubscribeBatch()
+    {
+        _subscription = await ChattyStream.SubscribeAsync(async (items) =>
+        {
+            _recievedMessage = items.Last().Item;
             if ("goodbye".Equals(_recievedMessage.Message, StringComparison.OrdinalIgnoreCase))
             {
                 if (_subscription != null)

--- a/test/OrleansTestKit.Tests/Interfaces/IChatty.cs
+++ b/test/OrleansTestKit.Tests/Interfaces/IChatty.cs
@@ -1,12 +1,15 @@
-﻿namespace TestInterfaces;
+﻿using TestGrains;
+
+namespace TestInterfaces;
 
 public interface IChatty : IGrainWithIntegerKey
 {
-    Task<(string Message, int Id)> GetMessage();
+    Task<ChattyMessage> GetMessage();
 
     Task SendChat(string msg);
 
     Task SendChatBatch(string[] msgs);
 
     Task Subscribe();
+    Task SubscribeBatch();
 }

--- a/test/OrleansTestKit.Tests/Tests/StreamBatchTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StreamBatchTests.cs
@@ -1,0 +1,47 @@
+﻿using FluentAssertions;
+using TestGrains;
+using Xunit;
+
+namespace Orleans.TestKit.Tests;
+
+public class StreamBatchTests : TestKitBase
+{
+    [Fact]
+    public async Task AddNonReferenceTypeStreamProbe()
+    {
+        var stream = Silo.AddStreamProbe<ChattyMessage>(Guid.Empty, null);
+
+        var chatty = await Silo.CreateGrainAsync<Chatty>(4);
+        await chatty.SubscribeBatch();
+
+        const string msg = "Hello Chat";
+        const int id = 2;
+        await stream.OnNextBatchAsync(new ChattyMessage[] { new(msg, id) });
+
+        stream.Sends.Should().Be(1);
+        stream.VerifySendBatch();
+
+        var message = await chatty.GetMessage();
+        Assert.NotEqual(default, message);
+        Assert.Equal(msg, message.Message);
+        Assert.Equal(id, message.Id);
+    }
+
+    [Fact]
+    public async Task GrainGetAllSubscriptionHandles()
+    {
+        var stream = Silo.AddStreamProbe<ChattyMessage>(Guid.Empty, null);
+
+        var chatty = await Silo.CreateGrainAsync<Chatty>(4);
+        await chatty.SubscribeBatch();
+        var handlers = await stream.GetAllSubscriptionHandles();
+
+        handlers.Count.Should().Be(1);
+        stream.Subscribed.Should().Be(1);
+
+        await handlers[0].UnsubscribeAsync();
+
+        handlers.Count.Should().Be(1);
+        stream.Subscribed.Should().Be(0);
+    }
+}

--- a/test/OrleansTestKit.Tests/Tests/StreamProbeStringTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StreamProbeStringTests.cs
@@ -1,0 +1,51 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using Orleans.TestKit.Streams;
+using Xunit;
+
+namespace Orleans.TestKit.Tests;
+
+public class StreamProbeStringTests : TestKitBase
+{
+    [Fact]
+    public void AddStreamProbe_WithStringStreamId_Populates_Correctly()
+    {
+        var streamId = Guid.NewGuid().ToString();
+
+        var stream = Silo.AddStreamProbe<object>(streamId);
+
+        AssertStream(stream, "Default", typeof(object).Name, streamId);
+    }
+
+    [Fact]
+    public void AddStreamProbe_WithStringStreamIdNamespace_Populates_Correctly()
+    {
+        var streamId = Guid.NewGuid().ToString();
+        var ns = Guid.NewGuid().ToString();
+
+        var stream = Silo.AddStreamProbe<object>(streamId, ns);
+
+        AssertStream(stream, "Default", ns, streamId);
+    }
+
+    [Fact]
+    public void AddStreamProbe_WithStringStreamIdNamespaceProvider_Populates_Correctly()
+    {
+        var streamId = Guid.NewGuid().ToString();
+        var ns = Guid.NewGuid().ToString();
+        var provider = Guid.NewGuid().ToString();
+
+        var stream = Silo.AddStreamProbe<object>(streamId, ns, provider);
+
+        AssertStream(stream, provider, ns, streamId);
+    }
+
+    private static void AssertStream(TestStream<object> stream, string provider, string streamNamespace, string streamId)
+    {
+        using var scope = new AssertionScope();
+
+        stream.ProviderName.Should().Be(provider);
+        stream.StreamId.GetNamespace().Should().Be(streamNamespace);
+        stream.StreamId.GetKeyAsString().Should().Be(streamId);
+    }
+}

--- a/test/OrleansTestKit.Tests/Tests/StreamTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StreamTests.cs
@@ -11,21 +11,21 @@ public class StreamTests : TestKitBase
     [Fact]
     public async Task AddNonReferenceTypeStreamProbe()
     {
-        var stream = Silo.AddStreamProbe<(string Message, int Id)>(Guid.Empty, null);
+        var stream = Silo.AddStreamProbe<ChattyMessage>(Guid.Empty, null);
 
         var chatty = await Silo.CreateGrainAsync<Chatty>(4);
         await chatty.Subscribe();
 
         const string msg = "Hello Chat";
         const int id = 2;
-        await stream.OnNextAsync((msg, id));
+        await stream.OnNextAsync(new(msg, id));
 
         stream.Sends.Should().Be(1);
         stream.VerifySend(m => m.Message == msg);
         stream.VerifySend(m => m.Id == id);
 
         var message = await chatty.GetMessage();
-        Assert.NotEqual(default((string Message, int Id)), message);
+        Assert.NotEqual(default, message);
         Assert.Equal(msg, message.Message);
         Assert.Equal(id, message.Id);
     }
@@ -60,7 +60,7 @@ public class StreamTests : TestKitBase
     [Fact]
     public async Task GrainIsUnsubscribed()
     {
-        var stream = Silo.AddStreamProbe<(string Message, int Id)>(Guid.Empty, null);
+        var stream = Silo.AddStreamProbe<ChattyMessage>(Guid.Empty, null);
 
         var chatty = await Silo.CreateGrainAsync<Chatty>(4);
         await chatty.Subscribe();
@@ -69,7 +69,7 @@ public class StreamTests : TestKitBase
 
         const string msg = "Goodbye";
         const int id = 3;
-        await stream.OnNextAsync((msg, id));
+        await stream.OnNextAsync(new(msg, id));
 
         stream.Sends.Should().Be(1);
         stream.VerifySend(m => m.Message == msg);


### PR DESCRIPTION
Orleans 7 introduces string-based stream keys (not just Guid) -- this PR adds those overloads to the TestKit

Also added Batch Observer support to the TestKit -- emulated Orleans behaviors when invoking OnNextBatchAsync