### PR TITLE
Set RuntimeContext and make IGrainContext injectable during Grain's construction / activation

### DIFF
--- a/src/OrleansTestKit/TestGrainCreator.cs
+++ b/src/OrleansTestKit/TestGrainCreator.cs
@@ -2,53 +2,46 @@
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Core;
 using Orleans.Runtime;
+using Orleans.TestKit.Reminders;
 using Orleans.TestKit.Storage;
 
 // Took the Get Factory Method from the Orleans Implementation :
 // https://github.com/dotnet/orleans/blob/10af0f4af588cd4aa45cb3e250dfbffa389d59c7/src/Orleans.Runtime/Facet/ConstructorArgumentFactory.cs
-
 namespace Orleans.TestKit;
 
+/// <summary>
+/// Contains necessary logic for creating grains in a unit test context -- emulates the Orleans runtime behavior of triggering lifecycle events, etc.
+/// </summary>
 public sealed class TestGrainCreator
 {
-    private const string GRAINCONTEXT_PROPERTYNAME = "GrainContext";
-
-    private const string RUNTIME_PROPERTYNAME = "Runtime";
-
-    private static readonly Action<IGrainContext> SetExecutionContextMethod = typeof(GrainReference).Assembly.GetType("Orleans.Runtime.RuntimeContext")
-        .GetMethod("SetExecutionContext", BindingFlags.NonPublic | BindingFlags.Static, new[] { typeof(IGrainContext) })!
-        .CreateDelegate<Action<IGrainContext>>()
-    ;
-
-    private static readonly Type FacetMarkerInterfaceType = typeof(IFacetMetadata);
-
-    private static readonly MethodInfo GetFactoryMethod = typeof(TestGrainCreator).GetMethod("GetFactory", BindingFlags.NonPublic | BindingFlags.Static);
-
-    private readonly PropertyInfo _contextProperty;
-
-    private readonly IGrainRuntime _runtime;
-
-    private readonly PropertyInfo _runtimeProperty;
+    private static readonly MethodInfo GetFactoryMethod = typeof(TestGrainCreator).GetMethod("GetFactory", BindingFlags.NonPublic | BindingFlags.Static)!;
 
     private readonly IServiceProvider _serviceProvider;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestGrainCreator"/> class.
+    /// </summary>
+    /// <param name="runtime">The grain runtime.</param>
+    /// <param name="serviceProvider">Service provider.</param>
+    /// <exception cref="ArgumentNullException">Both runtime and services should be not null.</exception>
     public TestGrainCreator(IGrainRuntime runtime, IServiceProvider serviceProvider)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        ArgumentNullException.ThrowIfNull(runtime);
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(runtime));
-        _contextProperty = typeof(Grain).GetProperty(GRAINCONTEXT_PROPERTYNAME, BindingFlags.Instance | BindingFlags.NonPublic);
-        _runtimeProperty = typeof(Grain).GetProperty(RUNTIME_PROPERTYNAME, BindingFlags.Instance | BindingFlags.NonPublic);
     }
 
+    /// <summary>
+    /// Create a grain instance emulating Orleans runtime behavior.
+    /// </summary>
+    /// <typeparam name="T">The grain instance type to create.</typeparam>
+    /// <param name="context">The grain context.</param>
+    /// <returns>The grain.</returns>
+    /// <exception cref="ArgumentNullException">context is required.</exception>
     public Grain CreateGrainInstance<T>(IGrainContext context)
     {
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
-        // this needs to remain set for the lifetime of the grain -- Orleans has hooks to validate that its set
-        SetExecutionContextMethod(context);
+        using var runtimeContextScope = RuntimeContextManager.StartExecutionContext(context);
 
         var (instances, types) = GetConstructorParameters(typeof(T), context);
         var factory = ActivatorUtilities.CreateFactory(typeof(T), types.ToArray());
@@ -59,46 +52,25 @@ public sealed class TestGrainCreator
         participant?.Participate(context.ObservableLifecycle);
 
         return grain;
-
-        // Set the runtime and identity. This is equivalent to what Orleans' GrainCreator does when creating new grains.
-        // It is messier but easier than trying to wrangle the values in via a constructor which may or may exist on
-        // types inheriting from Grain.
-        //var runtimeBackfield = _runtimeProperty.DeclaringType.GetField($"<{_runtimeProperty.Name}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
-        //runtimeBackfield.SetValue(grain, _runtime);
-        //_contextProperty.SetValue(grain, context);
-
-        // return grain;
     }
 
     /// <summary>
     ///     https://github.com/dotnet/orleans/blob/10af0f4af588cd4aa45cb3e250dfbffa389d59c7/src/Orleans.Runtime/Facet/ConstructorArgumentFactory.cs.
     /// </summary>
-    /// <typeparam name="TMetadata"></typeparam>
-    /// <param name="services"></param>
-    /// <param name="parameter"></param>
-    /// <param name="metadata"></param>
-    /// <param name="type"></param>
-    /// <returns></returns>
-    /// <exception cref="OrleansException"></exception>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used via reflection")]
     private static Factory<IGrainContext, object> GetFactory<TMetadata>(IServiceProvider services, ParameterInfo parameter, IFacetMetadata metadata, Type type)
          where TMetadata : IFacetMetadata
     {
-        var factoryMapper = services.GetService<IAttributeToFactoryMapper<TMetadata>>();
-        if (factoryMapper == null)
-        {
-            throw new OrleansException($"Missing attribute mapper for attribute {metadata.GetType()} used in grain constructor for grain type {type}.");
-        }
+        var factoryMapper = services.GetService<IAttributeToFactoryMapper<TMetadata>>()
+            ?? throw new OrleansException($"Missing attribute mapper for attribute {metadata.GetType()} used in grain constructor for grain type {type}.");
 
-        var factory = factoryMapper.GetFactory(parameter, (TMetadata)metadata);
-        if (factory == null)
-        {
-            throw new OrleansException($"Attribute mapper {factoryMapper.GetType()} failed to create a factory for grain type {type}.");
-        }
+        var factory = factoryMapper.GetFactory(parameter, (TMetadata)metadata)
+            ?? throw new OrleansException($"Attribute mapper {factoryMapper.GetType()} failed to create a factory for grain type {type}.");
 
         return factory;
     }
 
-    private void CreateIStorageParameter(ParameterInfo parameter, ref List<object> instances, ref HashSet<Type> types)
+    private static void CreateIStorageParameter(ParameterInfo parameter, ICollection<object> instances, HashSet<Type> types)
     {
         var stateType = parameter.ParameterType.GenericTypeArguments[0];
         var storageType = typeof(TestStorage<>).MakeGenericType(stateType);
@@ -106,7 +78,7 @@ public sealed class TestGrainCreator
         try
         {
             var state = Activator.CreateInstance(stateType);
-            var storage = Activator.CreateInstance(storageType, state);
+            var storage = Activator.CreateInstance(storageType, state)!;
 
             // cache argument factory
             instances.Add(storage);
@@ -143,7 +115,7 @@ public sealed class TestGrainCreator
 
                 var attribute = parameter
                     .GetCustomAttributes()
-                    .FirstOrDefault(x => FacetMarkerInterfaceType.IsInstanceOfType(x));
+                    .FirstOrDefault(x => typeof(IFacetMetadata).IsInstanceOfType(x));
 
                 // avoid duplicate instances of same parameter type when multiple constructors are available
                 if (types.Contains(parameter.ParameterType))
@@ -154,7 +126,7 @@ public sealed class TestGrainCreator
                 if (attribute != null)
                 {
                     var getFactory = GetFactoryMethod.MakeGenericMethod(attribute.GetType());
-                    var argumentFactory = (Factory<IGrainContext, object>)getFactory.Invoke(this, new object[] { _serviceProvider, parameter, attribute, grainType });
+                    var argumentFactory = (Factory<IGrainContext, object>)getFactory.Invoke(this, new object[] { _serviceProvider, parameter, attribute, grainType })!;
 
                     // cache argument factory
                     instances.Add(argumentFactory(context));
@@ -169,7 +141,7 @@ public sealed class TestGrainCreator
                     {
                         if (interf.IsGenericType && interf.GetGenericTypeDefinition() == typeof(IStorage<>))
                         {
-                            CreateIStorageParameter(parameter, ref instances, ref types);
+                            CreateIStorageParameter(parameter, instances, types);
                             continue;
                         }
                     }

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -67,20 +67,25 @@ public sealed class TestKitSilo
     /// <summary>Gets the manager of all test silo timers.</summary>
     public TestTimerRegistry TimerRegistry { get; }
 
-    public Task<T> CreateGrainAsync<T>(long id) where T : Grain, IGrainWithIntegerKey =>
+    public Task<T> CreateGrainAsync<T>(long id)
+        where T : Grain, IGrainWithIntegerKey =>
         CreateGrainAsync<T>(GrainIdKeyExtensions.CreateIntegerKey(id));
 
-    public Task<T> CreateGrainAsync<T>(Guid id) where T : Grain, IGrainWithGuidKey =>
+    public Task<T> CreateGrainAsync<T>(Guid id)
+        where T : Grain, IGrainWithGuidKey =>
         CreateGrainAsync<T>(GrainIdKeyExtensions.CreateGuidKey(id));
 
-    public Task<T> CreateGrainAsync<T>(string id) where T : Grain, IGrainWithStringKey =>
-        CreateGrainAsync<T>(IdSpan.Create(id));
+    public Task<T> CreateGrainAsync<T>(string id)
+        where T : Grain, IGrainWithStringKey
+        => CreateGrainAsync<T>(IdSpan.Create(id));
 
-    public Task<T> CreateGrainAsync<T>(Guid id, string keyExtension) where T : Grain, IGrainWithGuidCompoundKey =>
-        CreateGrainAsync<T>(GrainIdKeyExtensions.CreateGuidKey(id, keyExtension));
+    public Task<T> CreateGrainAsync<T>(Guid id, string keyExtension)
+        where T : Grain, IGrainWithGuidCompoundKey
+        => CreateGrainAsync<T>(GrainIdKeyExtensions.CreateGuidKey(id, keyExtension));
 
-    public Task<T> CreateGrainAsync<T>(long id, string keyExtension) where T : Grain, IGrainWithIntegerCompoundKey =>
-        CreateGrainAsync<T>(GrainIdKeyExtensions.CreateIntegerKey(id, keyExtension));
+    public Task<T> CreateGrainAsync<T>(long id, string keyExtension)
+        where T : Grain, IGrainWithIntegerCompoundKey
+        => CreateGrainAsync<T>(GrainIdKeyExtensions.CreateIntegerKey(id, keyExtension));
 
     /// <summary>Deactivate the given <see cref="Grain"/>.</summary>
     /// <param name="grain">Grain to Deactivate.</param>
@@ -88,6 +93,7 @@ public sealed class TestKitSilo
     ///     Reason which will passed to the Grian <seealso cref="DeactivationReason"/>.
     /// </param>
     /// <param name="cancellationToken">Token which will passed to the grain.</param>
+    /// <returns>Deactivation task.</returns>
     public async Task DeactivateAsync(Grain grain, DeactivationReason? deactivationReason = null, CancellationToken cancellationToken = default)
     {
         if (grain == null)
@@ -144,7 +150,8 @@ public sealed class TestKitSilo
     public void VerifyRuntime(Expression<Action<IGrainRuntime>> expression, Func<Times> times) =>
         _grainRuntime.Mock.Verify(expression, times);
 
-    private async Task<T> CreateGrainAsync<T>(IdSpan identity, CancellationToken cancellation = default) where T : Grain
+    private async Task<T> CreateGrainAsync<T>(IdSpan identity, CancellationToken cancellation = default)
+        where T : Grain
     {
         if (_isGrainCreated)
         {
@@ -160,7 +167,7 @@ public sealed class TestKitSilo
 
             // GrainIdentity = identity,
             GrainType = typeof(T),
-            ObservableLifecycle = _grainLifecycle
+            ObservableLifecycle = _grainLifecycle,
         };
 
         // make context injectable so grain dependency components can inject IGrainContext directly themselves
@@ -186,17 +193,13 @@ public sealed class TestKitSilo
         if (grain is IGrainBase)
         {
             // Used to enable reminder context on during activate
-            IDisposable? reminderContext = null;
-
-            if (grain is IRemindable)
-            {
-                reminderContext = await GetReminderActivationContext(grain, cancellation).ConfigureAwait(false);
-            }
+            using var reminderContext = grain is IRemindable
+                ? await GetReminderActivationContext(grain, cancellation).ConfigureAwait(false)
+                : null
+            ;
 
             await grain.OnActivateAsync(cancellation).ConfigureAwait(false);
             _activatedGrains.Add(grain);
-
-            reminderContext?.Dispose();
         }
 
         return (T)grain;

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -39,6 +39,7 @@ public sealed class TestKitSilo
         ServiceProvider.AddService<IKeyedServiceCollection<string, IStreamProvider>>(StreamProviderManager);
         ServiceProvider.AddService<IReminderRegistry>(ReminderRegistry);
         _grainRuntime = new TestGrainRuntime(GrainFactory, TimerRegistry, ReminderRegistry, ServiceProvider, StorageManager);
+        ServiceProvider.AddService<IGrainRuntime>(_grainRuntime);
         _grainCreator = new TestGrainCreator(_grainRuntime, ServiceProvider);
     }
 
@@ -161,6 +162,9 @@ public sealed class TestKitSilo
             GrainType = typeof(T),
             ObservableLifecycle = _grainLifecycle
         };
+
+        // make context injectable so grain dependency components can inject IGrainContext directly themselves
+        ServiceProvider.AddService<IGrainContext>(grainContext);
 
         // Create a stateless grain
         var grain = _grainCreator.CreateGrainInstance<T>(grainContext);

--- a/src/OrleansTestKit/Utilities/RuntimeContextManager.cs
+++ b/src/OrleansTestKit/Utilities/RuntimeContextManager.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using Orleans.Runtime;
+
+namespace Orleans.TestKit.Reminders;
+
+internal sealed class RuntimeContextManager
+{
+    private RuntimeContextManager()
+    {
+        var assembly = typeof(GrainId).Assembly;
+        var contextType = assembly.GetType("Orleans.Runtime.RuntimeContext")!;
+
+        SetExecutionContext = contextType
+            .GetMethod("SetExecutionContext", BindingFlags.NonPublic | BindingFlags.Static, new Type[] { typeof(IGrainContext) })!
+            .CreateDelegate<Action<IGrainContext?>>()
+        ;
+    }
+
+    public static RuntimeContextManager Instance { get; } = new RuntimeContextManager();
+
+    public Action<IGrainContext?> SetExecutionContext { get; }
+
+    public static IDisposable StartExecutionContext(IGrainContext context) => new RuntimeContextScope(context);
+
+    public void ResetExecutionContext() => SetExecutionContext(null);
+
+    private sealed class RuntimeContextScope : IDisposable
+    {
+        public RuntimeContextScope(IGrainContext context) => Instance.SetExecutionContext(context);
+
+        public void Dispose() => Instance.ResetExecutionContext();
+    }
+}

--- a/test/OrleansTestKit.Tests/Grains/ContextConstructorGrain.cs
+++ b/test/OrleansTestKit.Tests/Grains/ContextConstructorGrain.cs
@@ -1,0 +1,10 @@
+﻿namespace OrleansTestKit.Tests.Grains;
+public class ContextConstructorGrain : Grain, IGrainWithIntegerKey
+{
+    public ContextConstructorGrain()
+    {
+        var id = ((IGrainBase)this).GrainContext.GrainId;
+
+        GrainFactory.Equals(null); // this will blow up w/ a null ref exception if runtime isn't set properly
+    }
+}

--- a/test/OrleansTestKit.Tests/Grains/ContextConstructorGrain.cs
+++ b/test/OrleansTestKit.Tests/Grains/ContextConstructorGrain.cs
@@ -1,10 +1,39 @@
-﻿namespace OrleansTestKit.Tests.Grains;
+﻿using FluentAssertions;
+using Orleans.Runtime;
+
+namespace OrleansTestKit.Tests.Grains;
 public class ContextConstructorGrain : Grain, IGrainWithIntegerKey
 {
-    public ContextConstructorGrain()
+    public ContextConstructorGrain(IGrainContext injectedContext)
     {
-        var id = ((IGrainBase)this).GrainContext.GrainId;
+        injectedContext.Should().NotBeNull();
 
-        GrainFactory.Equals(null); // this will blow up w/ a null ref exception if runtime isn't set properly
+        var context = ((IGrainBase)this).GrainContext;
+
+        context.Should().NotBeNull();
+
+        context.Should().Be(injectedContext);
+
+        context.GrainId.Should().NotBeNull();
+
+        GrainFactory.Should().NotBeNull();
+    }
+}
+
+// TODO -- re-architect service provider to use automocking solution instead of of rolling by hand to allow for bigger "units" of testing
+public class LifecycleComponent : ILifecycleParticipant<IGrainLifecycle>
+{
+    private readonly IGrainContext _context;
+
+    public LifecycleComponent(IGrainContext context) => _context = context;
+
+    public bool IsInitialized { get; private set; }
+
+    public void Participate(IGrainLifecycle observer) => _context.ObservableLifecycle.Subscribe(nameof(LifecycleComponent), GrainLifecycleStage.Activate - 1, PreActivateAsync);
+
+    private Task PreActivateAsync(CancellationToken arg)
+    {
+        IsInitialized = true;
+        return Task.CompletedTask;
     }
 }

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <RootNamespace>Orleans.TestKit.Tests</RootNamespace>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>

--- a/test/OrleansTestKit.Tests/Tests/ContextConstructorGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ContextConstructorGrainTests.cs
@@ -6,8 +6,5 @@ namespace OrleansTestKit.Tests.Tests;
 public class ContextConstructorGrainTests : TestKitBase
 {
     [Fact]
-    public async Task CanAccess_GrainContext_InConstructorAsync()
-    {
-        await Silo.CreateGrainAsync<ContextConstructorGrain>(0);
-    }
+    public async Task CanAccess_GrainContext_InConstructorAsync() => await Silo.CreateGrainAsync<ContextConstructorGrain>(0);
 }

--- a/test/OrleansTestKit.Tests/Tests/ContextConstructorGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ContextConstructorGrainTests.cs
@@ -1,8 +1,8 @@
-﻿using Orleans.TestKit;
-using OrleansTestKit.Tests.Grains;
+﻿using OrleansTestKit.Tests.Grains;
 using Xunit;
 
-namespace OrleansTestKit.Tests.Tests;
+namespace Orleans.TestKit.Tests;
+
 public class ContextConstructorGrainTests : TestKitBase
 {
     [Fact]

--- a/test/OrleansTestKit.Tests/Tests/ContextConstructorGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ContextConstructorGrainTests.cs
@@ -1,0 +1,13 @@
+﻿using Orleans.TestKit;
+using OrleansTestKit.Tests.Grains;
+using Xunit;
+
+namespace OrleansTestKit.Tests.Tests;
+public class ContextConstructorGrainTests : TestKitBase
+{
+    [Fact]
+    public async Task CanAccess_GrainContext_InConstructorAsync()
+    {
+        await Silo.CreateGrainAsync<ContextConstructorGrain>(0);
+    }
+}


### PR DESCRIPTION
There are places in Orleans that require the RuntimeContext to be set (such as reminders) to ensure you are accessing from a grain context (not some background thread)

This change also fixes a couple of issues / inconsistencies:
1. Can access grain context / runtime in the grain's constructor
2. Can inject `IGrainContext` into grain dependencies as needed
3. Can access grain context / runtime in grain's lifecycle participation.