### PR TITLE
Fix GitHub Actions warnings on custom variables

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
             curl --header 'Accept: application/octet-stream' --header "Authorization: token ${GITHUB_TOKEN}" --location --remote-header-name --remote-name "${url}"
           done
           nupkg_files=(*.nupkg)
-          echo "::set-output name=nupkg_name::$( basename ${nupkg_files[-1]} )"
+          echo "nupkg_name=$( basename ${nupkg_files[-1]} )" >> "${GITHUB_OUTPUT}"
       - name: Publish NuGet Packages
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,11 @@ jobs:
           dotnet build --configuration Release --no-restore --verbosity minimal
           dotnet pack --configuration Release --no-restore --verbosity minimal
           nupkg_files=(artifacts/Release/*.nupkg)
-          echo "::set-output name=nupkg_name::$( basename ${nupkg_files[-1]} )"
-          echo "::set-output name=nupkg_path::${nupkg_files[-1]}"
+          echo "nupkg_name=$( basename ${nupkg_files[-1]} )" >> "${GITHUB_OUTPUT}"
+          echo "nupkg_path=${nupkg_files[-1]}" >> "${GITHUB_OUTPUT}"
           snupkg_files=(artifacts/Release/*.snupkg)
-          echo "::set-output name=snupkg_name::$( basename ${snupkg_files[-1]} )"
-          echo "::set-output name=snupkg_path::${snupkg_files[-1]}"
+          echo "snupkg_name=$( basename ${snupkg_files[-1]} )" >> "${GITHUB_OUTPUT}"
+          echo "snupkg_path=${snupkg_files[-1]}" >> "${GITHUB_OUTPUT}"
       - name: Create GitHub Release
         id: create_github_release
         uses: actions/create-release@master


### PR DESCRIPTION
This fixes some GitHub Actions warnings that occurred due to setting custom variables during the jobs. There is a new style based on "environment files":

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/