### PR TITLE
Add back method support for PersistentStateFacets

### DIFF
--- a/src/OrleansTestKit/Storage/StorageExtensions.cs
+++ b/src/OrleansTestKit/Storage/StorageExtensions.cs
@@ -1,26 +1,88 @@
-﻿using Orleans.TestKit.Storage;
+﻿using Orleans.Core;
+using Orleans.Runtime;
+using Orleans.TestKit.Storage;
 
 namespace Orleans.TestKit;
 
 public static class StorageExtensions
 {
-    public static TState State<TState>(this TestKitSilo silo) where TState : class, new()
+    public static TState State<TGrain, TState>(this TestKitSilo silo)
+        where TGrain : Grain<TState>
     {
-        if (silo == null)
-        {
-            throw new ArgumentNullException(nameof(silo));
-        }
+        ArgumentNullException.ThrowIfNull(silo);
 
-        return silo.StorageManager.GetStorage<TState>().State;
+        return silo.StorageManager.GetGrainStorage<TGrain, TState>().State;
     }
 
-    public static TestStorageStats? StorageStats(this TestKitSilo silo)
+    public static TestStorageStats? StorageStats<TGrain, TState>(this TestKitSilo silo)
+        where TGrain : Grain<TState>
     {
-        if (silo == null)
+        ArgumentNullException.ThrowIfNull(silo);
+
+        return silo.StorageManager.GetStorageStats<TGrain, TState>();
+    }
+
+    public static IStorage<TState> AddGrainState<TGrain, TState>(this TestKitSilo silo, TState? state = default)
+        where TGrain : Grain<TState>
+    {
+        ArgumentNullException.ThrowIfNull(silo);
+
+        var storage = silo.StorageManager.GetGrainStorage<TGrain, TState>();
+        storage.State = state ?? Activator.CreateInstance<TState>();
+        return storage;
+    }
+
+    /// <summary>
+    /// Add persistent state to the silo for a given type. If a state is provided that will be the loaded state otherwise a new <typeparamref name="T"/>
+    /// </summary>
+    /// <remarks>
+    /// If neither StateName or StorageName are provided then we resolve just based on type, otherwise we try state name and optionally a storage name
+    /// </remarks>
+    /// <typeparam name="T">The type of data in the state</typeparam>
+    /// <param name="silo">The silo to add the state to</param>
+    /// <param name="stateName">The state name on the persistent state parameter</param>
+    /// <param name="storageName">The storage name on the persistent state parameter</param>
+    /// <param name="state">The state to set as default if any</param>
+    /// <returns>The persistent state</returns>
+    public static IPersistentState<T> AddPersistentState<T>(
+        this TestKitSilo silo,
+        string stateName,
+        string? storageName = default,
+        T? state = default) =>
+        silo.AddPersistentStateStorage(
+            stateName,
+            storageName,
+            new TestStorage<T>(state ?? Activator.CreateInstance<T>()));
+
+    /// <summary>
+    /// Add persistent state to the silo for a given type. If a storage is provided that will provide the loaded state otherwise a new <typeparamref name="T"/>
+    /// </summary>
+    /// <remarks>
+    /// If neither StateName or StorageName are provided then we resolve just based on type, otherwise we try state name and optionally a storage name
+    /// </remarks>
+    /// <typeparam name="T">The type of data in the state</typeparam>
+    /// <param name="silo">The silo to add the state to</param>
+    /// <param name="stateName">The state name on the persistent state parameter</param>
+    /// <param name="storageName">The storage name on the persistent state parameter</param>
+    /// <param name="storage">The storage to use, if null a default implementation will be created</param>
+    /// <returns>The persistent state</returns>
+    public static IPersistentState<T> AddPersistentStateStorage<T>(
+        this TestKitSilo silo,
+        string stateName,
+        string? storageName = default,
+        IStorage<T>? storage = default)
+    {
+        ArgumentNullException.ThrowIfNull(silo);
+
+        if (string.IsNullOrWhiteSpace(stateName))
         {
-            throw new ArgumentNullException(nameof(silo));
+            throw new ArgumentException("A state name must be provided", nameof(stateName));
         }
 
-        return silo.StorageManager.StorageStats;
+        var normalizedStorage = storage ?? new TestStorage<T>(Activator.CreateInstance<T>());
+        var normalizedStorageName = storageName ?? "Default";
+
+        silo.StorageManager.AddStorage(normalizedStorage, stateName);
+        return silo.StorageManager.StateAttributeFactoryMapper.AddPersistentState(normalizedStorage, stateName, normalizedStorageName);
     }
 }

--- a/src/OrleansTestKit/Storage/StorageManager.cs
+++ b/src/OrleansTestKit/Storage/StorageManager.cs
@@ -1,4 +1,5 @@
-﻿using Orleans.Core;
+﻿using System.Diagnostics.CodeAnalysis;
+using Orleans.Core;
 
 namespace Orleans.TestKit.Storage;
 
@@ -6,33 +7,104 @@ public sealed class StorageManager
 {
     private readonly TestKitOptions _options;
 
-    private object? _storage;
+    private readonly Dictionary<string, object> _storages = new();
 
-    public StorageManager(TestKitOptions options) =>
-        _options = options ?? throw new ArgumentNullException(nameof(options));
-
-    public TestStorageStats? StorageStats
+    public StorageManager(TestKitOptions options)
     {
-        get
-        {
-            // There should only be one state in here since there is only 1 grain under test
-            var stats = _storage as IStorageStats;
-            return stats?.Stats;
-        }
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        StateAttributeFactoryMapper = new TestPersistentStateAttributeToFactoryMapper(this);
     }
 
-    public IStorage<TState> GetStorage<TState>()
+    internal TestPersistentStateAttributeToFactoryMapper StateAttributeFactoryMapper { get; }
+
+    public IStorage<TState> GetGrainStorage<TGrain, TState>() where TGrain : Grain<TState>
+        => GetStorage<TState>(typeof(TGrain).FullName!);
+
+    public IStorage<TState> GetStorage<TState>(string stateName)
     {
-        if (_storage == null)
+        if (string.IsNullOrWhiteSpace(stateName))
         {
-            _storage = _options.StorageFactory?.Invoke(typeof(TState)) ?? new TestStorage<TState>();
+            foreach (var kvp in _storages)
+            {
+                if (kvp.Value is TestStorage<TState> typedStorage)
+                {
+                    return typedStorage;
+                }
+            }
+
+            throw new InvalidOperationException($"Unable to find any storage with type '{typeof(TState).FullName}'");
         }
 
-        if (_storage is not IStorage<TState> storage)
+        if (_storages.TryGetValue(stateName, out var storage) is false)
         {
-            throw new Exception($"The custom storage must implement IStorage<{typeof(TState).Name}>");
+            storage = _storages[stateName] = _options.StorageFactory?.Invoke(typeof(TState)) ?? new TestStorage<TState>();
         }
 
-        return storage;
+        return (IStorage<TState>)storage;
+    }
+
+    /// <summary>
+    /// Get the storage stats for the provided grain with <typeparamref name="TState"></typeparamref> state object.
+    /// </summary>
+    /// <typeparam name="TGrain">The type of the grain with the state</typeparam>
+    /// <typeparam name="TState">The type of the state</typeparam>
+    /// <returns>The storage stats if they exist</returns>
+    public TestStorageStats? GetStorageStats<TGrain, TState>() where TGrain : Grain<TState>
+        => GetStorageStats(typeof(TGrain).FullName);
+
+    /// <summary>
+    /// Get the storage stats for the state with the provided <paramref name="stateName"/> or "Default" if not provided.
+    /// </summary>
+    /// <param name="stateName">The name of the state or if not provided "Default"</param>
+    /// <returns>The storage stats if they exist for the state</returns>
+    public TestStorageStats? GetStorageStats(string? stateName)
+    {
+        var normalisedStateName = stateName ?? "Default";
+
+        if (_storages.TryGetValue(normalisedStateName, out var storage))
+        {
+            var stats = storage as IStorageStats;
+            return stats?.Stats;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Try to get the storage stats for the provided provided grain with <typeparamref name="TState"></typeparamref> object.
+    /// </summary>
+    /// <param name="stats">The <see cref="TestStorageStats"/> if they are found or <see langword="null"/> if not.</param>
+    /// <typeparam name="TGrain">The type of the grain with the state</typeparam>
+    /// <typeparam name="TState">The type of the state</typeparam>
+    /// <returns><see langword="true"/> if <see cref="TestStorageStats"/> are found or <see langword="false"/> if not</returns>
+    public bool TryGetStorageStats<TGrain, TState>([NotNullWhen(true)] out TestStorageStats? stats)
+        where TGrain : Grain<TState>
+        => TryGetStorageStats(typeof(TGrain).FullName, out stats);
+
+    /// <summary>
+    /// Try to get the storage stats for the state with the provided <paramref name="stateName"/> or "Default" if not provided.
+    /// </summary>
+    /// <param name="stateName">The name of the state or if not provided "Default"</param>
+    /// <param name="stats">The <see cref="TestStorageStats"/> if they are found or <see langword="null"/> if not.</param>
+    /// <returns><see langword="true"/> if <see cref="TestStorageStats"/> are found or <see langword="false"/> if not</returns>
+    public bool TryGetStorageStats(string? stateName, [NotNullWhen(true)] out TestStorageStats? stats)
+    {
+        var normalisedStateName = stateName ?? "Default";
+
+        if (_storages.TryGetValue(normalisedStateName, out var storage) && storage is IStorageStats storageWithStats)
+        {
+            stats = storageWithStats.Stats;
+            return true;
+        }
+
+        stats = default;
+        return false;
+    }
+
+    internal void AddStorage<TState>(IStorage<TState> storage, string? stateName = default)
+    {
+        var normalisedStateName = stateName ?? "Default";
+
+        _storages[normalisedStateName] = storage;
     }
 }

--- a/src/OrleansTestKit/Storage/TestPersistentStateAttributeToFactoryMapper.cs
+++ b/src/OrleansTestKit/Storage/TestPersistentStateAttributeToFactoryMapper.cs
@@ -1,0 +1,149 @@
+﻿using System.Reflection;
+using Orleans.Core;
+using Orleans.Runtime;
+
+namespace Orleans.TestKit.Storage;
+
+public sealed class TestPersistentStateAttributeToFactoryMapper : IAttributeToFactoryMapper<PersistentStateAttribute>
+{
+    private static readonly MethodInfo _addEmptyStateMethod = typeof(TestPersistentStateAttributeToFactoryMapper)
+        .GetMethod(nameof(AddEmptyState), BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private readonly Dictionary<Type, Dictionary<(string StateName, string StorageName), object>>
+        _registeredStorage = new();
+
+    private readonly StorageManager _storageManager;
+
+    public TestPersistentStateAttributeToFactoryMapper(StorageManager storageManager) =>
+        _storageManager = storageManager;
+
+    public Factory<IGrainContext, object> GetFactory(ParameterInfo parameter,
+        PersistentStateAttribute metadata)
+    {
+        ArgumentNullException.ThrowIfNull(parameter);
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        if (parameter.ParameterType.IsGenericType &&
+            parameter.ParameterType.GetGenericTypeDefinition() != typeof(IPersistentState<>))
+        {
+            throw new InvalidOperationException($"No persistent state for the parameter '{parameter.Name}'");
+        }
+
+        var parameterType = parameter.ParameterType.GenericTypeArguments[0];
+        var stateName = metadata.StateName;
+        var storageName = metadata.StorageName ?? "Default";
+
+        if (_registeredStorage.TryGetValue(parameterType, out var typeStateRegistry))
+        {
+            // If we must have the state and the storage name so lookup by both
+            if (typeStateRegistry.TryGetValue((metadata.StateName, storageName), out var persistentState))
+            {
+                return _ => persistentState;
+            }
+        }
+
+        var state = _addEmptyStateMethod.MakeGenericMethod(parameterType).Invoke(
+            this,
+            new object?[] { stateName, storageName })!;
+
+        return _ => state;
+    }
+
+    public IPersistentState<T> AddPersistentState<T>(
+        IStorage<T> storage,
+        string stateName,
+        string storageName)
+    {
+        if (storage is null)
+        {
+            throw new ArgumentNullException(nameof(storage));
+        }
+
+        if (string.IsNullOrWhiteSpace(stateName))
+        {
+            throw new ArgumentException($"'{nameof(stateName)}' cannot be null or whitespace.", nameof(stateName));
+        }
+
+        if (string.IsNullOrWhiteSpace(storageName))
+        {
+            throw new ArgumentException($"'{nameof(storageName)}' cannot be null or whitespace.", nameof(storageName));
+        }
+
+        var dict = _registeredStorage.TryGetValue(typeof(T), out var typeStateRegistry)
+            ? typeStateRegistry
+            : _registeredStorage[typeof(T)] = new Dictionary<(string StateName, string StorageName), object>(1);
+
+        var fake = new PersistentStateFake<T>(storage);
+        dict[(stateName, storageName)] = fake;
+
+        return fake;
+    }
+
+    private IPersistentState<TState> AddEmptyState<TState>(string stateName, string storageName)
+    {
+        var storage = _storageManager.GetStorage<TState>(stateName);
+        return AddPersistentState(storage, stateName, storageName);
+    }
+}
+
+internal class PersistentStateFake<TState> : IPersistentState<TState>, IStorageStats
+{
+    private readonly IStorage<TState> _storage;
+    private readonly TestStorageStats? _stats;
+
+    public PersistentStateFake(IStorage<TState> storage)
+    {
+        _storage = storage;
+
+        // If the underlying storage doesn't have stats we should wrap it in our own.
+        if (_storage is IStorageStats is false)
+        {
+            _stats = new TestStorageStats();
+        }
+    }
+
+    public TState State
+    {
+        get => _storage.State;
+        set => _storage.State = value;
+    }
+
+    public string Etag => _storage.Etag;
+
+    public bool RecordExists => _storage.RecordExists;
+
+    public Task ClearStateAsync()
+    {
+        if (_stats is not null)
+        {
+            _stats.Clears++;
+        }
+
+        return _storage.ClearStateAsync();
+    }
+
+    public Task ReadStateAsync()
+    {
+        if (_stats is not null)
+        {
+            _stats.Reads++;
+        }
+
+        return _storage.ReadStateAsync();
+    }
+
+    public Task WriteStateAsync()
+    {
+        if (_stats is not null)
+        {
+            _stats.Writes++;
+        }
+
+        return _storage.WriteStateAsync();
+    }
+
+    public TestStorageStats Stats =>
+        _storage is IStorageStats statsStorage
+            ? statsStorage.Stats
+            : _stats!;
+}

--- a/src/OrleansTestKit/TestGrainRuntime.cs
+++ b/src/OrleansTestKit/TestGrainRuntime.cs
@@ -70,6 +70,19 @@ public sealed class TestGrainRuntime : IGrainRuntime
     }
 
     /// <inheritdoc/>
-    public IStorage<TGrainState> GetStorage<TGrainState>(IGrainContext grain) =>
-        _storageManager.GetStorage<TGrainState>();
+    public IStorage<TGrainState> GetStorage<TGrainState>(IGrainContext grainContext)
+    {
+        ArgumentNullException.ThrowIfNull(grainContext);
+
+        // Getting storage from the IGrainContext either use the grain type
+        // from the TestGrainActivationContext if possible otherwise
+        // use GrainInstance.
+        var grainType = grainContext is TestGrainActivationContext testContext
+            ? testContext.GrainType
+            : grainContext.GrainInstance?.GetType();
+
+        ArgumentNullException.ThrowIfNull(grainType);
+
+        return _storageManager.GetStorage<TGrainState>(grainType.FullName!);
+    }
 }

--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -216,6 +216,9 @@ public sealed class TestKitSilo
                 "A grain has already been created in this silo. Only 1 grain per test silo should ever be created. Add grain probes for supporting grains.");
         }
 
+        // Add state attribute mapping for storage facets
+        this.AddService<IAttributeToFactoryMapper<PersistentStateAttribute>>(StorageManager.StateAttributeFactoryMapper);
+
         _isGrainCreated = true;
 
         var grainContext = GetOrAddGrainContext<T>(identity);

--- a/test/OrleansTestKit.Tests/Grains/ColorRankingGrain.cs
+++ b/test/OrleansTestKit.Tests/Grains/ColorRankingGrain.cs
@@ -1,0 +1,69 @@
+﻿using Orleans.Runtime;
+using TestInterfaces;
+
+namespace TestGrains;
+
+public class ColorRankingGrain : Grain<ColorGrainState>, IColorRankingGrain
+{
+    /// <summary>The persisted state.</summary>
+    private readonly IPersistentState<ColorGrainState> state;
+
+    public ColorRankingGrain(
+        [PersistentState("Default")] IPersistentState<ColorGrainState> state) =>
+        this.state = state;
+
+    public Task<Color> GetFavouriteColor() => Task.FromResult(state.State.Color);
+
+    public Task<Color> GetLeastFavouriteColor() => Task.FromResult(State.Color);
+
+    /// <summary>Asynchronously sets the favourite color.</summary>
+    /// <param name="color">The new color.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="ArgumentNullException">
+    ///     If <paramref name="color" /> is <see cref="Color.Unknown" /> or an invalid value.
+    /// </exception>
+    public async Task SetFavouriteColor(Color color)
+    {
+        SetColor(color, state.State);
+        await state.WriteStateAsync();
+    }
+
+    /// <summary>Asynchronously sets the least favourite color.</summary>
+    /// <param name="color">The new color.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="ArgumentNullException">
+    ///     If <paramref name="color" /> is <see cref="Color.Unknown" /> or an invalid value.
+    /// </exception>
+    public async Task SetLeastFavouriteColor(Color color)
+    {
+        SetColor(color, State);
+        await WriteStateAsync();
+    }
+
+    private void SetColor(Color color, ColorGrainState state)
+    {
+        if (!Enum.IsDefined(typeof(Color), color))
+        {
+            throw new ArgumentException("The color is invalid.", nameof(color));
+        }
+
+        if (color == Color.Unknown)
+        {
+            throw new ArgumentException("The color must not be \"unknown\".", nameof(color));
+        }
+
+        if (this.state.State.Initialized)
+        {
+            if (color == state.Color)
+            {
+                return;
+            }
+        }
+        else
+        {
+            state.Id = this.GetPrimaryKey();
+        }
+
+        state.Color = color;
+    }
+}

--- a/test/OrleansTestKit.Tests/Interfaces/IColorRankingGrain.cs
+++ b/test/OrleansTestKit.Tests/Interfaces/IColorRankingGrain.cs
@@ -1,0 +1,9 @@
+﻿namespace TestInterfaces;
+
+public interface IColorRankingGrain : IGrainWithGuidKey
+{
+    Task<Color> GetFavouriteColor();
+    Task<Color> GetLeastFavouriteColor();
+    Task SetFavouriteColor(Color color);
+    Task SetLeastFavouriteColor(Color color);
+}

--- a/test/OrleansTestKit.Tests/Tests/PersistantStreamNotWithinGrainStateTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/PersistantStreamNotWithinGrainStateTests.cs
@@ -10,8 +10,6 @@ namespace Orleans.TestKit.Tests;
 
 public class PersistantStreamNotWithinGrainStateTests : TestKitBase
 {
-    private readonly Mock<IPersistentState<PersistentListenerStateWithoutHandle>> _persistentState;
-
     private readonly PersistentListenerStateWithoutHandle _stateWithoutHandle;
 
     private readonly TestStream<ChatMessage> _stream;
@@ -20,15 +18,8 @@ public class PersistantStreamNotWithinGrainStateTests : TestKitBase
     {
         _stateWithoutHandle = new PersistentListenerStateWithoutHandle();
 
-        _persistentState = new Mock<IPersistentState<PersistentListenerStateWithoutHandle>>();
-        _persistentState.SetupGet(o => o.State).Returns(_stateWithoutHandle);
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o =>
-                o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>()))
-            .Returns(context => _persistentState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState(
+            "listenerStateWithoutHandler", state: _stateWithoutHandle);
 
         _stream = Silo.AddStreamProbe<ChatMessage>(Guid.Empty, null, "Default");
     }

--- a/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageFacetTests.cs
@@ -1,7 +1,6 @@
-﻿using System.Reflection;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Moq;
-using Orleans.Runtime;
+using Orleans.Core;
 using Orleans.Storage;
 using TestGrains;
 using TestInterfaces;
@@ -19,13 +18,7 @@ public class StorageFacetTests : TestKitBase
         // Arrange
         var state = new ColorGrainState();
 
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
-        mockState.SetupGet(o => o.State).Returns(state);
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState<ColorGrainState>("State");
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -40,19 +33,9 @@ public class StorageFacetTests : TestKitBase
     public async Task GetColor_WithState_ReturnsColor()
     {
         // Arrange
-        var state = new ColorGrainState
-        {
-            Color = Color.Red,
-            Id = GrainId,
-        };
+        var state = new ColorGrainState { Color = Color.Red, Id = GrainId };
 
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
-        mockState.SetupGet(o => o.State).Returns(state);
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState("State", state: state);
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -69,13 +52,7 @@ public class StorageFacetTests : TestKitBase
         // Arrange
         var state = new ColorGrainState();
 
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
-        mockState.SetupGet(o => o.State).Returns(state);
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState("State", state: state);
 
         // Act
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
@@ -91,14 +68,7 @@ public class StorageFacetTests : TestKitBase
         // Arrange
         var state = new ColorGrainState();
 
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
-        mockState.SetupGet(o => o.State).Returns(state);
-        mockState.Setup(o => o.ClearStateAsync());
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState("State", state: state);
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -112,27 +82,17 @@ public class StorageFacetTests : TestKitBase
         // Note that the following assert ties this test to the _implementation_ details. Generally, one should try to
         // avoid tying the test to the implementation details. It can lead to more brittle tests. However, one may
         // choose to accept this as a trade-off when the implementation detail represents an important behavior.
-        mockState.Verify(o => o.ClearStateAsync(), Times.Never);
+        var storageStats = Silo.StorageManager.GetStorageStats("State");
+        storageStats.Clears.Should().Be(0);
     }
 
     [Fact]
     public async Task ResetColor_WithState_ClearsState()
     {
         // Arrange
-        var state = new ColorGrainState
-        {
-            Color = Color.Red,
-            Id = GrainId,
-        };
+        var state = new ColorGrainState { Color = Color.Red, Id = GrainId };
 
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
-        mockState.SetupGet(o => o.State).Returns(state);
-        mockState.Setup(o => o.ClearStateAsync());
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState("State", state: state);
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -140,7 +100,8 @@ public class StorageFacetTests : TestKitBase
         await grain.ResetColor();
 
         // Assert
-        mockState.Verify(o => o.ClearStateAsync(), Times.Once);
+        var storageStats = Silo.StorageManager.GetStorageStats("State");
+        storageStats.Clears.Should().Be(1);
     }
 
     [Fact]
@@ -149,14 +110,7 @@ public class StorageFacetTests : TestKitBase
         // Arrange
         var state = new ColorGrainState();
 
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
-        mockState.SetupGet(o => o.State).Returns(state);
-        mockState.Setup(o => o.WriteStateAsync());
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState("State", state: state);
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -174,16 +128,7 @@ public class StorageFacetTests : TestKitBase
     public async Task SetColor_WithInvalidColor_ThrowsArgumentException(Color color)
     {
         // Arrange
-        var state = new ColorGrainState();
-
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
-        mockState.SetupGet(o => o.State).Returns(state);
-        mockState.Setup(o => o.WriteStateAsync());
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState<ColorGrainState>("State");
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
         Action action = () => grain.SetColor(color);
@@ -199,14 +144,11 @@ public class StorageFacetTests : TestKitBase
         // Arrange
         var state = new ColorGrainState();
 
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
+        var mockState = new Mock<IStorage<ColorGrainState>>();
         mockState.SetupGet(o => o.State).Returns(state);
         mockState.Setup(o => o.WriteStateAsync()).Throws<InconsistentStateException>();
 
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentStateStorage("State", storage: mockState.Object);
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
         Action action = () => grain.SetColor(Color.Green);
@@ -219,20 +161,9 @@ public class StorageFacetTests : TestKitBase
     public async Task SetColor_WithState_SetsState()
     {
         // Arrange
-        var state = new ColorGrainState
-        {
-            Color = Color.Red,
-            Id = GrainId,
-        };
+        var state = new ColorGrainState { Color = Color.Red, Id = GrainId };
 
-        var mockState = new Mock<IPersistentState<ColorGrainState>>();
-        mockState.SetupGet(o => o.State).Returns(state);
-        mockState.Setup(o => o.ClearStateAsync());
-
-        var mockMapper = new Mock<IAttributeToFactoryMapper<PersistentStateAttribute>>();
-        mockMapper.Setup(o => o.GetFactory(It.IsAny<ParameterInfo>(), It.IsAny<PersistentStateAttribute>())).Returns(context => mockState.Object);
-
-        Silo.AddService(mockMapper.Object);
+        Silo.AddPersistentState("State", state: state);
 
         var grain = await Silo.CreateGrainAsync<ColorGrain>(GrainId);
 
@@ -242,5 +173,78 @@ public class StorageFacetTests : TestKitBase
         // Assert
         state.Color.Should().Be(Color.Blue);
         state.Id.Should().Be(GrainId);
+    }
+
+    [Fact]
+    public async Task GetColor_WithGrainState_ReturnsColor()
+    {
+        // Arrange
+        var state = new ColorGrainState { Color = Color.Red, Id = GrainId };
+
+        Silo.AddGrainState<ColorRankingGrain, ColorGrainState>(state);
+
+        var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+        // Act
+        var color = await grain.GetLeastFavouriteColor();
+        color.Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public async Task SetLeastFavouriteColor_WithDefaultGrainState_SetsState()
+    {
+        var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+        // Act
+        await grain.SetLeastFavouriteColor(Color.Blue);
+
+        var storage = Silo.StorageManager.GetGrainStorage<ColorRankingGrain, ColorGrainState>();
+        var state = storage.State;
+
+        state.Color.Should().Be(Color.Blue);
+        state.Id.Should().Be(GrainId);
+    }
+
+    [Fact]
+    public async Task GetLeastFavouriteColor_WithGrainState_ReturnsColor()
+    {
+        // Arrange
+        var state = new ColorGrainState { Color = Color.Red, Id = GrainId };
+
+        Silo.AddGrainState<ColorRankingGrain, ColorGrainState>(state);
+
+        var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+        // Act
+        var color = await grain.GetLeastFavouriteColor();
+        color.Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public async Task SetFavouriteColor_WithState_SetsState()
+    {
+        var persistentState =
+            Silo.AddPersistentState("Default", state: new ColorGrainState { Id = GrainId, Color = Color.Red });
+
+        var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+        // Act
+        await grain.SetFavouriteColor(Color.Blue);
+
+        var state = persistentState.State;
+        state.Color.Should().Be(Color.Blue);
+        state.Id.Should().Be(GrainId);
+    }
+
+    [Fact]
+    public async Task GetFavouriteColor_WithState_ReturnsColor()
+    {
+        Silo.AddPersistentState("Default", state: new ColorGrainState { Id = GrainId, Color = Color.Blue });
+
+        var grain = await Silo.CreateGrainAsync<ColorRankingGrain>(GrainId);
+
+        // Act
+        var color = await grain.GetFavouriteColor();
+        color.Should().Be(Color.Blue);
     }
 }

--- a/test/OrleansTestKit.Tests/Tests/StorageTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StorageTests.cs
@@ -78,10 +78,10 @@ public class StorageTests : TestKitBase
         var greetings = (await grain.GetGreetings()).ToList();
 
         // Assert
-        var state = this.Silo.State<GreetingArchiveGrainState>();
+        var state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
         state.Greetings.Should().Equal(greeting1, greeting2);
         greetings.Should().Equal(greeting1, greeting2);
-        Assert.True(this.Silo.StorageManager.GetStorage<GreetingArchiveGrainState>().RecordExists);
+        Assert.True(this.Silo.StorageManager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>().RecordExists);
     }
 
     /// <summary>
@@ -105,13 +105,13 @@ public class StorageTests : TestKitBase
         var greetings = (await grain.GetGreetings()).ToList();
 
         // Assert
-        var stats = this.Silo.StorageStats()!;
+        var stats = this.Silo.StorageStats<GreetingArchiveGrain, GreetingArchiveGrainState>();
         stats.Clears.Should().Be(0);
         stats.Reads.Should().Be(0);
         stats.Writes.Should().Be(2);
 
         greetings.Should().Equal(greeting1, greeting2);
-        Assert.True(this.Silo.StorageManager.GetStorage<GreetingArchiveGrainState>().RecordExists);
+        Assert.True(this.Silo.StorageManager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>().RecordExists);
     }
 
     /// <summary>
@@ -125,7 +125,7 @@ public class StorageTests : TestKitBase
         const long id = 2000;
         const string greeting = "Hola";
 
-        var state = this.Silo.State<GreetingArchiveGrainState>();
+        var state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
         state.Greetings.Add(greeting);
 
         var grain = await this.Silo.CreateGrainAsync<GreetingArchiveGrain>(id);
@@ -182,7 +182,7 @@ public class StorageTests : TestKitBase
         const long id = 5000;
         const string greeting = "Olá";
 
-        var state = this.Silo.State<GreetingArchiveGrainState>();
+        var state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
         state.Greetings.Add(greeting);
 
         var grain = await this.Silo.CreateGrainAsync<GreetingArchiveGrain>(id);
@@ -193,11 +193,11 @@ public class StorageTests : TestKitBase
         var greetings = (await grain.GetGreetings()).ToList();
 
         // Assert
-        state = this.Silo.State<GreetingArchiveGrainState>();
+        state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
         state.Greetings.Should().BeEmpty();
 
         greetings.Should().BeEmpty();
-        Assert.False(this.Silo.StorageManager.GetStorage<GreetingArchiveGrainState>().RecordExists);
+        Assert.False(this.Silo.StorageManager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>().RecordExists);
     }
 
     /// <summary>
@@ -211,7 +211,7 @@ public class StorageTests : TestKitBase
         const long id = 6000;
         const string greeting = "Hallo";
 
-        var state = this.Silo.State<GreetingArchiveGrainState>();
+        var state = this.Silo.State<GreetingArchiveGrain, GreetingArchiveGrainState>();
         state.Greetings.Add(greeting);
 
         var grain = await this.Silo.CreateGrainAsync<GreetingArchiveGrain>(id);
@@ -222,13 +222,13 @@ public class StorageTests : TestKitBase
         var greetings = (await grain.GetGreetings()).ToList();
 
         // Assert
-        var stats = this.Silo.StorageStats()!;
+        var stats = this.Silo.StorageStats<GreetingArchiveGrain, GreetingArchiveGrainState>();
         stats.Clears.Should().Be(1);
         stats.Reads.Should().Be(0);
         stats.Writes.Should().Be(0);
 
         greetings.Should().BeEmpty();
-        Assert.False(this.Silo.StorageManager.GetStorage<GreetingArchiveGrainState>().RecordExists);
+        Assert.False(this.Silo.StorageManager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>().RecordExists);
     }
 
     /// <summary>This test demonstrates how to use the RecordExists flag</summary>
@@ -236,7 +236,7 @@ public class StorageTests : TestKitBase
     public async Task RecordExistsFlagTest()
     {
         var manager = new StorageManager(new TestKitOptions());
-        var state = manager.GetStorage<GreetingArchiveGrainState>();
+        var state = manager.GetGrainStorage<GreetingArchiveGrain, GreetingArchiveGrainState>();
 
         // be default, RecordExists is false
         Assert.False(state.RecordExists);

--- a/test/OrleansTestKit.Tests/Tests/TimerTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/TimerTests.cs
@@ -16,7 +16,7 @@ public class TimerTests : TestKitBase
         await Silo.FireAllTimersAsync();
 
         // Assert
-        var state = Silo.State<HelloTimersState>();
+        var state = Silo.State<HelloTimers, HelloTimersState>();
         state.Timer0Fired.Should().BeTrue();
         state.Timer1Fired.Should().BeTrue();
     }
@@ -32,7 +32,7 @@ public class TimerTests : TestKitBase
         await Silo.FireAllTimersAsync();
 
         // Assert
-        var state = Silo.State<HelloTimersState>();
+        var state = Silo.State<HelloTimers, HelloTimersState>();
         state.Timer0Fired.Should().BeTrue();
         state.Timer1Fired.Should().BeTrue();
         state.Timer2Fired.Should().BeTrue();
@@ -49,7 +49,7 @@ public class TimerTests : TestKitBase
         await Silo.FireTimerAsync(0);
 
         // Assert
-        var state = Silo.State<HelloTimersState>();
+        var state = Silo.State<HelloTimers, HelloTimersState>();
         state.Timer0Fired.Should().BeTrue();
         state.Timer1Fired.Should().BeFalse();
     }
@@ -64,7 +64,7 @@ public class TimerTests : TestKitBase
         await Silo.FireTimerAsync(1);
 
         // Assert
-        var state = Silo.State<HelloTimersState>();
+        var state = Silo.State<HelloTimers, HelloTimersState>();
         state.Timer0Fired.Should().BeFalse();
         state.Timer1Fired.Should().BeTrue();
     }


### PR DESCRIPTION
Hi there,

The changes in #105 got lost during the migration to orleans 7.0. This returns all the changes on top of main branch

Original issue: #55