### PR TITLE
Concurrent Test Grain Factory

### DIFF
--- a/test/OrleansTestKit.Tests/Tests/ConcurrentGrainFactoryTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ConcurrentGrainFactoryTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using TestInterfaces;
+using Xunit;
+
+namespace Orleans.TestKit.Tests.Tests;
+
+public class ConcurrentGrainFactoryTests : TestKitBase
+{
+    private readonly IClusterClient _clusterClient;
+
+    public ConcurrentGrainFactoryTests()
+    {
+        Silo.AddProbe(id => Mock.Of<IPong>());
+        _clusterClient = Silo.ServiceProvider.GetRequiredService<IClusterClient>();
+    }
+
+    [Fact]
+    public void ParallelInvoke_GrainFactory_DifferentKeys_Success()
+    {
+        Parallel.For(0, 100, i =>
+        {
+            _ = _clusterClient.GetGrain<IPong>(i);
+        });
+    }
+
+    [Fact]
+    public void ParallelInvoke_GrainFactory_SameKey_ReturnsSameGrain()
+    {
+        var results = Enumerable.Range(0, 100).AsParallel().Select(x => _clusterClient.GetGrain<IPong>(0)).ToArray();
+
+        results.Distinct().Should().HaveCount(1);
+    }
+}

--- a/test/OrleansTestKit.Tests/Tests/StrictGrainProbeTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/StrictGrainProbeTests.cs
@@ -22,7 +22,7 @@ public class StrictGrainProbeTests : TestKitBase
         //This uses the wrong id for the IPong since this is hard coded within PingGrain
         var pong = Silo.AddProbe<IPong>(0);
 
-        await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<Exception>();
+        await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<InvalidOperationException>();
 
         pong.Verify(p => p.Pong(), Times.Never);
     }
@@ -35,7 +35,7 @@ public class StrictGrainProbeTests : TestKitBase
         //This uses the correct id, but the wrong grain type
         var pong = Silo.AddProbe<IPong2>(22);
 
-        await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<Exception>();
+        await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<InvalidOperationException>();
 
         pong.Verify(p => p.Pong2(), Times.Never);
     }
@@ -45,7 +45,7 @@ public class StrictGrainProbeTests : TestKitBase
     {
         IPing grain = await Silo.CreateGrainAsync<PingGrain>(1);
 
-        await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<Exception>();
+        await grain.Invoking(p => p.Ping()).Should().ThrowExactlyAsync<InvalidOperationException>();
     }
 
     [Fact]


### PR DESCRIPTION
The `TestGrainFactory` can be invoked outside the Orleans thread-safety guarantees in a parallel fashion by code that is invoking via `IClusterClient` and should offer functionality for concurrency guarantees.

I received an error in some new code in our codebase that we had to re-shape business logic to satisfy the unit test error