### PR TITLE
(4.x backport) correct the double call to OnActivateAsync on IRemindable grains

### DIFF
--- a/src/OrleansTestKit/TestKitSilo.cs
+++ b/src/OrleansTestKit/TestKitSilo.cs
@@ -251,14 +251,10 @@ public sealed class TestKitSilo
             // Used to enable reminder context on during activate
             using var reminderContext =
                  await GetReminderActivationContext(grain, cancellation).ConfigureAwait(false);
-
-            await grain.OnActivateAsync(cancellation).ConfigureAwait(false);
-            _activatedGrains.Add(grain);
         }
 
         await grain.OnActivateAsync(cancellation).ConfigureAwait(false);
         _activatedGrains.Add(grain);
-
 
         return (T)grain;
     }

--- a/test/OrleansTestKit.Tests/Grains/ActivationCountWithReminder.cs
+++ b/test/OrleansTestKit.Tests/Grains/ActivationCountWithReminder.cs
@@ -1,0 +1,38 @@
+﻿using Orleans.Runtime;
+using Orleans.Streams;
+
+namespace TestGrains;
+
+public sealed class ActivationCountWithReminder : Grain, IGrainWithIntegerKey, IRemindable
+{
+    private int _activationCount;
+
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        _activationCount++;
+        return base.OnActivateAsync(cancellationToken);
+    }
+
+    public Task<int> GetActivationCount() => Task.FromResult(_activationCount);
+
+
+    Task IRemindable.ReceiveReminder(string reminderName, TickStatus status)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task RegisterReminder(string reminderName, TimeSpan dueTime, TimeSpan period)
+    {
+        return this.RegisterOrUpdateReminder(reminderName, dueTime, period);
+    }
+
+    public async Task UnregisterReminder(string reminderName)
+    {
+        var reminder = await this.GetReminder(reminderName);
+
+        if (reminder != null)
+        {
+            await this.UnregisterReminder(reminder);
+        }
+    }
+}

--- a/test/OrleansTestKit.Tests/Tests/ActivationGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/ActivationGrainTests.cs
@@ -32,4 +32,16 @@ public class ActivationGrainTests : TestKitBase
         await Assert.ThrowsAsync<NotSupportedException>(
             async () => await Silo.CreateGrainAsync<StatefulUnsupportedActivationGrain>(0));
     }
+
+    [Fact]
+    public async Task OnActivateAsyncShouldBeCalledOnceOnRemindable()
+    {
+        // Arrange
+
+        // Act
+        var grain = await Silo.CreateGrainAsync<ActivationCountWithReminder>(1);
+        var value = await grain.GetActivationCount();
+
+        Assert.Equal(1, value);
+    }
 }


### PR DESCRIPTION
backport of https://github.com/OrleansContrib/OrleansTestKit/pull/165
Test grain for tracking OnActivateAsync call count Test OnActivateAsync is only called once

for https://github.com/OrleansContrib/OrleansTestKit/issues/154 in the 4.x branch