### PR TITLE
Upgrade project dependencies and bump NuGet package version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Build
         run: |
           dotnet restore --verbosity minimal
-          dotnet build --configuration Release --no-restore --verbosity minimal
-          dotnet pack --configuration Release --no-restore --verbosity minimal
+          dotnet build --configuration Release --no-restore --verbosity minimal /p:ContinuousIntegrationBuild=true
+          dotnet pack --configuration Release --no-build --no-restore --verbosity minimal /p:ContinuousIntegrationBuild=true
       - name: Test
         run: |
-          dotnet test --configuration Release --no-build --no-restore --verbosity minimal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Include="[OrleansTestKit]*"
+          dotnet test --configuration Release --no-build --no-restore --verbosity minimal /p:ContinuousIntegrationBuild=true /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Include="[OrleansTestKit]*"
       - name: Upload NuGet Packages
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Packages
           path: artifacts/Release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Build
         id: build
         run: |
           dotnet restore --verbosity minimal
-          dotnet build --configuration Release --no-restore --verbosity minimal
-          dotnet pack --configuration Release --no-restore --verbosity minimal
+          dotnet build --configuration Release --no-restore --verbosity minimal /p:ContinuousIntegrationBuild=true
+          dotnet pack --configuration Release --no-build --no-restore --verbosity minimal /p:ContinuousIntegrationBuild=true
           nupkg_files=(artifacts/Release/*.nupkg)
           echo "nupkg_name=$( basename ${nupkg_files[-1]} )" >> "${GITHUB_OUTPUT}"
           echo "nupkg_path=${nupkg_files[-1]}" >> "${GITHUB_OUTPUT}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "dotnet-test-explorer.runInParallel": true,
   "dotnet-test-explorer.testProjectPath": "/test/*.Tests",
+  "dotnet.defaultSolution": "OrleansTestKit.sln",
   "editor.formatOnSave": true,
   "editor.minimap.maxColumn": 120,
   "editor.minimap.showSlider": "always",
@@ -14,8 +15,6 @@
     "**/bin": true,
     "**/obj": true
   },
-  "omnisharp.defaultLaunchSolution": "OrleansTestKit.sln",
   "omnisharp.enableEditorConfigSupport": true,
-  "omnisharp.enableRoslynAnalyzers": true,
   "omnisharp.useEditorFormattingSettings": false
 }

--- a/OrleansTestKit.sln
+++ b/OrleansTestKit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.8.34330.188
+VisualStudioVersion = 17.11.35222.181
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{54C04CF7-7044-46E0-BC24-2A992F028557}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     - [Visual Studio](#visual-studio)
     - [Visual Studio Code](#visual-studio-code)
   - [Community](#community)
+  - [License](#license)
 
 ## About
 

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestFeature",
-    "version": "8.0.100"
+    "version": "8.0.401"
   }
 }

--- a/src/OrleansTestKit/OrleansTestKit.csproj
+++ b/src/OrleansTestKit/OrleansTestKit.csproj
@@ -2,6 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Deterministic>true</Deterministic>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageDescription>A unit test toolkit for Microsoft Orleans that does not require a real silo. Instead, tests are run with a mock grain activation context.</PackageDescription>
@@ -9,10 +11,11 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageOutputPath Condition=" '$(PackageOutputPath)'=='' ">$(ProjectRoot)/artifacts/$(Configuration)</PackageOutputPath>
     <PackageProjectUrl>https://github.com/OrleansContrib/OrleansTestKit</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Orleans Cloud-Computing Actor-Model Actors Distributed-Systems C# .NET Test Testing</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -27,9 +30,9 @@
     <PackageReference Include="Microsoft.Orleans.Reminders" Version="8.2.0" />
     <PackageReference Include="Microsoft.Orleans.Streaming" Version="8.2.0" />
     <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
@@ -40,6 +43,7 @@
 
   <ItemGroup>
     <None Include="$(ProjectRoot)assets/logo_128.png" Pack="true" Visible="false" PackagePath="/" />
+    <None Include="$(ProjectRoot)README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
+++ b/test/OrleansTestKit.Tests/OrleansTestKit.Tests.csproj
@@ -6,20 +6,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FakeItEasy" Version="7.4.0" />
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.2.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.6.5" />
-    <PackageReference Include="xunit.analyzers" Version="1.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.16.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This prepares for a new v8 release. It upgrades the project dependencies and bumps the NuGet package version to 8.2.1.

Closes #167.