### PR TITLE
Make DeactivationOnIdle behaviour on POCO grain consistent

### DIFF
--- a/src/OrleansTestKit/TestGrainActivationContext.cs
+++ b/src/OrleansTestKit/TestGrainActivationContext.cs
@@ -1,4 +1,5 @@
-﻿using Orleans.Runtime;
+﻿using Moq;
+using Orleans.Runtime;
 
 namespace Orleans.TestKit;
 
@@ -7,6 +8,8 @@ namespace Orleans.TestKit;
 /// </summary>
 public sealed class TestGrainActivationContext : IGrainContext
 {
+    public readonly Mock<IGrainContext> Mock = new Mock<IGrainContext>();
+
     /// <inheritdoc/>
     public ActivationId ActivationId { get; set; }
 
@@ -47,7 +50,10 @@ public sealed class TestGrainActivationContext : IGrainContext
     public void Activate(Dictionary<string, object> requestContext, CancellationToken? cancellationToken = null) => throw new NotImplementedException();
 
     /// <inheritdoc/>
-    public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null) => throw new NotImplementedException();
+    public void Deactivate(DeactivationReason deactivationReason, CancellationToken? cancellationToken = null)
+    {
+        Mock.Object.Deactivate(deactivationReason);
+    }
 
     /// <inheritdoc/>
     public bool Equals(IGrainContext? other) => ReferenceEquals(this, other);
@@ -66,7 +72,10 @@ public sealed class TestGrainActivationContext : IGrainContext
 
     public void Activate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
 
-    public void Deactivate(DeactivationReason deactivationReason, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+    public void Deactivate(DeactivationReason deactivationReason, CancellationToken cancellationToken = new CancellationToken())
+    {
+        Mock.Object.Deactivate(deactivationReason, cancellationToken);
+    }
 
     /// <inheritdoc/>
     public void Rehydrate(IRehydrationContext context) => throw new NotImplementedException();

--- a/test/OrleansTestKit.Tests/Grains/DeactivationGrainPoco.cs
+++ b/test/OrleansTestKit.Tests/Grains/DeactivationGrainPoco.cs
@@ -1,0 +1,20 @@
+﻿using TestInterfaces;
+
+namespace TestGrains;
+
+public class DeactivationGrainPoco : IGrainBase, IDeactivationGrain
+{
+    public IGrainContext GrainContext { get; }
+
+    public new Task DeactivateOnIdle()
+    {
+        GrainBaseExtensions.DeactivateOnIdle(this);
+
+        return Task.CompletedTask;
+    }
+
+    public new Task DelayDeactivation(TimeSpan timeSpan)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/test/OrleansTestKit.Tests/Tests/DeactivationGrainTests.cs
+++ b/test/OrleansTestKit.Tests/Tests/DeactivationGrainTests.cs
@@ -37,5 +37,21 @@ public class DeactivationGrainTests : TestKitBase
         // Assert
         Silo.VerifyRuntime(i => i.DelayDeactivation(context, timeSpan), Times.Once);
     }
+
+    [Fact]
+    public async Task ShouldCallDeactivateOnIdleOnPoco()
+    {
+        // Arrange
+        var grain = await Silo.CreateGrainAsync<DeactivationGrainPoco>(0);
+
+        // Act
+        await grain.DeactivateOnIdle();
+
+        var context = Silo.GetContextFromGrain(grain);
+
+        // Assert
+        var reason = new DeactivationReason(DeactivationReasonCode.ApplicationRequested, $"{nameof(GrainBaseExtensions.DeactivateOnIdle)} was called.");
+        ((TestGrainActivationContext) context).Mock.Verify(i => i.Deactivate(reason, default), Times.Once);
+    }
 }
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
The current behaviour of a call to `DeactivateOnIdle` depends on whether the grain is a normal grain (deriving `Grain`) or a POCO grain (implementing `IGrainBase`). 
When called on the first a mocked implementation is called, while on the latter a `NotImplementedException` is thrown.

In my opinion the choice for either is an implementation detail and should not result in different grain behaviour.

This pull request proposes a change to make the behaviour of the latter consistent with the former.